### PR TITLE
Recibir objetos surveys en lugar de la clase encuesta

### DIFF
--- a/R/clases_surveytogo.R
+++ b/R/clases_surveytogo.R
@@ -865,23 +865,28 @@ Pregunta <- R6::R6Class("Pregunta",
                           graficadas = NULL,
                           tema = NULL,
                           initialize = function(encuesta, tema = tema_default){
+
                             self$encuesta <- encuesta
                             self$tema <- tema
                             self$regiones_shp()
 
                           },
+
                           graficar = function(llave, tipo, aspectos = NULL, filtro = NULL,
                                               llave_partido, llave_conocimiento,
                                               llave_opinion,
                                               llave_xq,
                                               parametros = list(tit = "",
                                                                 porcentajes_afuera = F,
-                                                                desplazar_porcentajes = 0.01)){
+                                                                desplazar_porcentajes = 0.01)
+                                              ){
 
                             tipo <- match.arg(tipo, choices = c("frecuencia", "promedio", "texto_barras", "texto_nube",
                                                                 "candidato_opinion", "candidato_saldo", "candidato_partido"))
                             if(tipo == "frecuencia"){
+
                               if(is.null(aspectos)){
+
                                 tipo_p <- self$encuesta$cuestionario$diccionario %>%
                                   filter(llaves == quo_name(enquo(llave))) %>% pull(tipo_pregunta)
 
@@ -912,6 +917,7 @@ Pregunta <- R6::R6Class("Pregunta",
                                     graficar_gauge_promedio(color = parametros$color, maximo = parametros$maximo,
                                                             familia = self$tema()$text$family)
                                 }
+
                                 else{
                                   llave_aux <- quo_name(enquo(llave))
                                   if(!(llave_aux %in% self$graficadas)){
@@ -954,6 +960,7 @@ Pregunta <- R6::R6Class("Pregunta",
                                     self$tema()
                                 }
                               }
+
                               else{
 
                                 if(quo_name(enquo(llave)) != "NULL") {
@@ -1418,6 +1425,7 @@ Pregunta <- R6::R6Class("Pregunta",
                               ) +
                               self$tema()
                           },
+
                           cruce_barras = function(por_grupo, variables, vartype = "cv", valor_variables, color, filter=NULL){
                             encuestar:::analizar_cruce_puntos(srvyr::as_survey_design(self$encuesta$muestra$diseno),
                                                               cruce = por_grupo,
@@ -1442,6 +1450,7 @@ Pregunta <- R6::R6Class("Pregunta",
                                                                 familia = self$tema()$text$family) +
                               self$tema()
                           },
+
                           cruce_bloque = function(cruce, variable, vartype = "cv", filter=NULL){
                             encuestar:::analizar_cruce_2vbrechas(srvyr::as_survey_design(self$encuesta$muestra$diseno),
                                                                  var1 = cruce,
@@ -1455,9 +1464,11 @@ Pregunta <- R6::R6Class("Pregunta",
                                                                  familia = self$tema()$text$family)
 
                           },
+
                           faltantes = function(){
                             gant_p_r(self$encuesta$cuestionario$diccionario %>% filter(!llaves %in% self$graficadas))
                           }
+
                         ))
 
 #' Title

--- a/R/clases_surveytogo.R
+++ b/R/clases_surveytogo.R
@@ -1048,29 +1048,38 @@ Pregunta <- R6::R6Class("Pregunta",
 
                             if(tipo == "gauge_categorica"){
 
-                              estimacion <- encuestar::analizar_frecuencias(diseno = self$encuesta$muestra$diseno,
-                                                                            pregunta = {{llave}})
+                              if(is.null(filtro)) {
 
-                              if(self$encuesta$tipo_encuesta %in% c("ine", "inegi")) {
-
-                                p <- estimacion %>%
-                                  pull(pregunta) %>%
-                                  unique
-
-                                p <- self$encuesta$cuestionario$diccionario %>%
-                                  filter(llaves == p) %>%
-                                  pull(pregunta)
-
-                                estimacion <- estimacion %>%
-                                  mutate(pregunta = p)
+                                stop(paste("Especifique la respuesta en la cual hacer filtro con el argumento `filtro`"))
 
                               }
 
-                              g <- estimacion %>%
-                                filter(eval(rlang::parse_expr(filtro))) %>%
-                                mutate(media = media) %>%
-                                graficar_gauge_promedio(color = parametros$color,
-                                                        size_text_pct = parametros$size_text_pct)
+                              if(!is.null(filtro)) {
+
+                                estimacion <- encuestar::analizar_frecuencias(diseno = self$encuesta$muestra$diseno,
+                                                                              pregunta = {{llave}})
+
+                                if(self$encuesta$tipo_encuesta %in% c("ine", "inegi")) {
+
+                                  p <- estimacion %>%
+                                    pull(pregunta) %>%
+                                    unique
+
+                                  p <- self$encuesta$cuestionario$diccionario %>%
+                                    filter(llaves == p) %>%
+                                    pull(pregunta)
+
+                                  estimacion <- estimacion %>%
+                                    mutate(pregunta = p)
+
+                                }
+
+                                g <- estimacion %>%
+                                  filter(eval(rlang::parse_expr(filtro))) %>%
+                                  mutate(media = media) %>%
+                                  graficar_gauge_promedio(color = parametros$color,
+                                                          size_text_pct = parametros$size_text_pct)
+                              }
 
                             }
 

--- a/R/clases_surveytogo.R
+++ b/R/clases_surveytogo.R
@@ -1249,8 +1249,11 @@ Pregunta <- R6::R6Class("Pregunta",
 
                           multirespuesta = function(patron_inicial, tit = "", salto = 100, nota = ""){
 
-                            g <-  analizar_frecuencia_multirespuesta(self$encuesta, patron_inicial) %>%
-                              graficar_barras_frecuencia(tit = tit, tema = self$tema, salto = salto, nota) + self$tema()
+                            g <-  analizar_frecuencia_multirespuesta(diseno = self$encuesta$muestra$diseno,
+                                                                     patron_inicial) %>%
+                              graficar_barras_frecuencia(tit = tit, tema = self$tema, salto = salto, nota) +
+                              self$tema()
+
                             return(g)
 
                           },

--- a/R/graficar.R
+++ b/R/graficar.R
@@ -244,25 +244,27 @@ if(getRversion() >= "2.15.1")  utils::globalVariables(c("familia"))
 #'
 #' @examples
 
-graficar_gauge_promedio <- function(bd, color = "#850D2D", maximo = 10, familia, texto = "\n Promedio", size_text_pct){
+graficar_gauge_promedio <- function(bd, color = "#850D2D", size_text_pct){
 
-  bd %>%
+  g <- bd %>%
     ggplot() +
     geom_rect(aes(xmin = 2, xmax = 3, ymin = 0, ymax = media),
               fill = color,  color = "white", alpha= .95) +
-    geom_rect(aes(xmin = 2, xmax = 3, ymin = media, ymax = maximo),
+    geom_rect(aes(xmin = 2, xmax = 3, ymin = media, ymax = 1.),
               fill = "grey90", color = "white") +
-    geom_text(aes(x = 0, y = media, label = scales::percent(x = media/100, accuracy = 1.)),
-              size = size_text_pct, family = familia, nudge_y = 0.25) +
+    geom_text(aes(x = 0, y = media, label = scales::percent(x = media, accuracy = 1.)),
+              size = size_text_pct, family = "Poppins", nudge_y = 0.25) +
     scale_fill_manual(values = c("#1DCDBC", "#38C6F4")) +
     scale_x_continuous(limits = c(0, NA)) +
-    scale_y_continuous(limits = c(0, maximo)) +
+    scale_y_continuous(limits = c(0, 1)) +
     xlab("") +
     ylab("") +
     coord_polar(theta = "y") +
     theme_void() +
     theme(legend.position = "bottom", axis.text = element_blank(),
-          text = element_text(size = 15, family = familia))
+          text = element_text(size = 15, family = "Poppins"))
+
+  return(g)
 
 }
 

--- a/R/graficar.R
+++ b/R/graficar.R
@@ -244,19 +244,32 @@ if(getRversion() >= "2.15.1")  utils::globalVariables(c("familia"))
 #'
 #' @examples
 
-graficar_gauge_promedio <- function(bd, color = "#850D2D", size_text_pct){
+graficar_gauge_promedio <- function(bd, color = "#850D2D", escala = c(0, 10), size_text_pct){
 
   g <- bd %>%
     ggplot() +
     geom_rect(aes(xmin = 2, xmax = 3, ymin = 0, ymax = media),
               fill = color,  color = "white", alpha= .95) +
-    geom_rect(aes(xmin = 2, xmax = 3, ymin = media, ymax = 1.),
-              fill = "grey90", color = "white") +
-    geom_text(aes(x = 0, y = media, label = scales::percent(x = media, accuracy = 1.)),
-              size = size_text_pct, family = "Poppins", nudge_y = 0.25) +
+    geom_rect(aes(xmin = 2, xmax = 3, ymin = media, ymax = escala[2]),
+              fill = "grey90", color = "white")
+
+  if(escala[2] == 1) {
+
+    g <- g + geom_text(aes(x = 0, y = media, label = scales::percent(x = media, accuracy = 1.)),
+                       size = size_text_pct, family = "Poppins", nudge_y = 0.25)
+
+  }
+  else {
+
+    g <- g + geom_text(aes(x = 0, y = media, label = scales::comma(x = media, accuracy = 1.1)),
+                       size = size_text_pct, family = "Poppins", nudge_y = 0.25)
+
+  }
+
+  g <- g +
     scale_fill_manual(values = c("#1DCDBC", "#38C6F4")) +
     scale_x_continuous(limits = c(0, NA)) +
-    scale_y_continuous(limits = c(0, 1)) +
+    scale_y_continuous(limits = c(0, escala[2])) +
     xlab("") +
     ylab("") +
     coord_polar(theta = "y") +

--- a/R/procesar_surveytogo.R
+++ b/R/procesar_surveytogo.R
@@ -448,11 +448,11 @@ analizar_morena <- function(encuesta, personajes, atributos){
 
 }
 
-analizar_frecuencia_multirespuesta <- function(encuesta, patron_inicial){
-  aux <- encuesta$muestra$diseno$variables %>%
-    select(starts_with(patron_inicial)) %>% as_tibble %>%
-    rownames_to_column() %>%
-    mutate(weight = weights(encuesta$muestra$diseno)) %>%
+analizar_frecuencia_multirespuesta <- function(diseno, patron_inicial){
+
+  aux <- diseno$variables %>%
+    tibble::rownames_to_column() %>%
+    mutate(weight = weights(diseno)) %>%
     pivot_longer(-c(rowname, weight)) %>%
     filter(!is.na(value)) %>%
     mutate(seleccion = 1) %>%
@@ -460,12 +460,12 @@ analizar_frecuencia_multirespuesta <- function(encuesta, patron_inicial){
     pivot_wider(names_from = value, values_from  = seleccion, values_fill = 0) %>%
     select(-rowname) %>% summarise(across(-weight, ~sum(.x*weight))) %>%
     pivot_longer(everything(), names_to = "respuesta", values_to = "value") %>%
-    mutate(media = value/sum(weights(encuesta$muestra$diseno)),
+    mutate(media = value/sum(weights(diseno)),
            respuesta=forcats::fct_reorder(.f = respuesta,
                                           .x = media,
-                                          .fun = max)
-    )
+                                          .fun = max))
   return(aux)
+
 }
 
 analizar_cruce_puntos <-  function(encuesta_diseño, cruce, variables, vartype, valor_variables){


### PR DESCRIPTION
Cambio de parámetro de la función "analizar_frecuencias_multirespuesta" para que en lugar de recibir la clase Encuesta y extraer el diseño, reciba únicamente el diseño y así pueda ser usada para la encuesta de la SEP