### PR TITLE
Mantenimiento Mayor: Clases y diseno muestral afectados

### DIFF
--- a/R/clases_surveytogo.R
+++ b/R/clases_surveytogo.R
@@ -2221,5 +2221,3 @@ Auditoria <- R6::R6Class("Auditoria",
                              rsconnect::deployApp(self$dir,...)
                            }
                          ))
-
-# Comentario de prueba

--- a/R/clases_surveytogo.R
+++ b/R/clases_surveytogo.R
@@ -604,7 +604,7 @@ Respuestas <- R6::R6Class("Respuestas",
                               if(tipo_encuesta == "ine"){
                                 self$base <- self$base %>%
                                   mutate(rango_edad = cut(as.numeric(edad), c(17,24,39,59,Inf),
-                                                          labels = c("18A24","25A39","40A60","60YMAS")),
+                                                          labels = c("18A24","25A39","40A59","60YMAS")),
                                          sexo = if_else(sexo == "Mujer", "F", "M"))
                               }
 

--- a/R/clases_surveytogo.R
+++ b/R/clases_surveytogo.R
@@ -1556,10 +1556,10 @@ Graficas <- R6::R6Class(classname = "Graficas",
                                                          tema = self$tema,
                                                          graficadas = self$graficadas)
 
-                             self$Regiones <- Regiones$new(diseno = self$encuesta$muestra$diseno,
-                                                           diccionario = self$encuesta$cuestionario$diccionario,
-                                                           shp = private$shp_region,
-                                                           tema = self$tema)
+                             # self$Regiones <- Regiones$new(diseno = self$encuesta$muestra$diseno,
+                             #                               diccionario = self$encuesta$cuestionario$diccionario,
+                             #                               shp = private$shp_region,
+                             #                               tema = self$tema)
 
                              self$Modelo <- Modelo$new(diseno = self$encuesta$muestra$diseno,
                                                        diccionario = self$encuesta$cuestionario$diccionario,
@@ -2221,5 +2221,3 @@ Auditoria <- R6::R6Class("Auditoria",
                              rsconnect::deployApp(self$dir,...)
                            }
                          ))
-
-# comentario de prueba

--- a/R/clases_surveytogo.R
+++ b/R/clases_surveytogo.R
@@ -2221,3 +2221,5 @@ Auditoria <- R6::R6Class("Auditoria",
                              rsconnect::deployApp(self$dir,...)
                            }
                          ))
+
+# Comentario de prueba

--- a/R/clases_surveytogo.R
+++ b/R/clases_surveytogo.R
@@ -2221,3 +2221,5 @@ Auditoria <- R6::R6Class("Auditoria",
                              rsconnect::deployApp(self$dir,...)
                            }
                          ))
+
+# comentario de prueba


### PR DESCRIPTION
Clases:

Las clases Descriptiva, Cruce, Especial, Regiones y Modelo reciben un nuevo parámetro llamado 'encuesta'. Como estaba construido antes, las clases recibían un único parámetro llamado 'diseno' el cual es el diseño muestral de la encuesta con que sse esté trabajando. 

Sin embargo, el uso de las clases no permitía explotar la función 'diseno_region' de la clase 'Muestra' (la cual nos permitía calcular resultados por región) o 'elegir_calibración' (calcula resultados usando una calibracion particular). Esto ocurre debido a que, al modificar el diseno muestral (encuesta$muestra$diseno) este cambio no se reflejaba una vez ejecutada la clase. Específicamente, no es lo mismo usar

Descriptiva$new(diseno = encuesta$muestra$diseno, ...),
                           initialize(diseno, ...){
                           self$diseno <- diseno
                           },
                           graficar_barras(...){
                           analizar_frecuencias(diseno = self$diseno, ...)
                           }

En lugar de:

Descriptiva$new(encuesta = encuesta,
                           diseno = NULL,
                           ...),
                           initialize(encuesta, diseno, ...){
                           self$encuesta <- encuesta
                           self$diseno <- diseno
                           },
                           graficar_barras(...){
                           analizar_frecuencias(diseno = self$encuesta$muestra$diseno, ...)
                           }

Ya que, en el primer caso, al definir el parametro 'diseno' de la clase "Descriptiva" se extrae el diseño muestral de la clase encuesta pero si ese diseño se modifica con las funciones 'diseno_region' o 'elegir_calibracion' la modificación no se "actualiza" a la clase "Descriptiva" pues se ha declarado el diseno al ejecutar la clase. En el segundo caso, sí se actualiza este diseno por lo que es posible usar todas las características de la paquetería.

Las adecuaciones preparan las clases para correr sin la clase 'Encuesta', únicamente con un diseño muestral.

Diseño muestral:

Los rango de edad calculados en la clase 'Respuestas' deben coincidir con los proporcionados en el diseño muestral. Antes, había un error al construir diseños pues se consideraban los rangos de edad c("18A24", "25A39", "40A60", "60YMAS")
y ahora se actualizó a c("18A24","25A39","40A59","60YMAS").

Es importante saber que, cualquier diseño muestra anterior a la encuesta de estatal de Chiapas en Enero de 2024 NO va a poder procesarse con esta nueva versión del paquete. Es decir, las encuestas inmediatas anteriores (Tijuana, Enero 2024. Morenos, Enero 2024, Tuxtla, Noviembre 2023, etc), no van a poder procesarse (no corre la clase 'Encuesta$new'.


