### PR TITLE
Indicar origen de paqueteria

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,6 +62,7 @@ VignetteBuilder:
 Remotes:
     hrbrmstr/ggchicklet,
     davidsjoberg/ggsankey
+    morant-consultores/encuestar
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
ShinyApps.io da problemas al publicar aplicaciones que dependan de encuestar. Indicar que encuestar es remoto es una sugerencia de chatGPT