### PR TITLE
Fixes de teoría muestral: fallback sin conglomerados, lonely PSU y monitor de rake

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,5 +66,5 @@ Remotes:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
 Config/testthat/edition: 3
+Config/roxygen2/version: 8.0.0

--- a/R/clase_muestra.R
+++ b/R/clase_muestra.R
@@ -172,6 +172,31 @@ Muestra <-
 
             pobG <- pob %>% count(rango_edad, wt = value, name = "Freq")
             pobS<- pob %>% count(sexo, wt = value, name = "Freq")
+
+            # margen degenerado (categoria con respondientes pero Freq 0/NA
+            # en el marco, tipico de una columna del marco toda NA):
+            # survey::rake fallaria con "Strata in sample absent from
+            # population. This Can't Happen" — se valida antes con un
+            # error accionable
+            for (margen in list(list(bd = pobG, var = "rango_edad"),
+                                list(bd = pobS, var = "sexo"))) {
+              en_muestra <- unique(stats::na.omit(respuestas[[margen$var]]))
+              con_freq <- margen$bd[[margen$var]][
+                !is.na(margen$bd$Freq) & margen$bd$Freq > 0
+              ]
+              faltantes <- setdiff(en_muestra, con_freq)
+              if (length(faltantes) > 0) {
+                stop(
+                  "El margen poblacional de `", margen$var, "` esta en 0 o NA ",
+                  "para categoria(s) presentes en la muestra: ",
+                  paste(faltantes, collapse = ", "),
+                  ". Revisa las columnas correspondientes del marco muestral ",
+                  "antes de rakear.",
+                  call. = FALSE
+                )
+              }
+            }
+
             self$diseno <- survey::rake(diseno, list(~rango_edad, ~sexo), list(pobG, pobS))
 
             # Monitoreo de los factores de ajuste del rake: sin cuotas en
@@ -182,7 +207,18 @@ Muestra <-
             # marco) no es señal de desbalance
             factor_rake <- as.numeric(stats::weights(self$diseno)) /
               as.numeric(stats::weights(diseno))
-            factor_rake <- factor_rake / stats::median(factor_rake)
+            mediana_rake <- stats::median(factor_rake, na.rm = TRUE)
+            if(!is.finite(mediana_rake) || mediana_rake <= 0 ||
+                 any(!is.finite(factor_rake))){
+              warning(
+                "No se pudo evaluar la calidad del rake: hay factores no ",
+                "finitos o mediana <= 0. Revisa si algun margen poblacional ",
+                "del marco es 0/NA para una categoria con respondientes.",
+                call. = FALSE
+              )
+              return(invisible(NULL))
+            }
+            factor_rake <- factor_rake / mediana_rake
             message(sprintf(
               "Factores de ajuste del rake: min %.2f | mediana %.2f | max %.2f.",
               min(factor_rake), stats::median(factor_rake), max(factor_rake)

--- a/R/clase_muestra.R
+++ b/R/clase_muestra.R
@@ -90,8 +90,14 @@ Muestra <-
       #'  estándar (~25% medido en Chihuahua Ene-2026). Usa `TRUE` solo como
       #'  decisión consciente del analista; se emite un warning y el diseño se
       #'  construye estratificado sin conglomerados.
+      #' @param umbral_rake Vector `c(inferior, superior)` con el rango aceptable
+      #'  de los factores de ajuste del rake (default `c(0.5, 2)`). Sin cuotas en
+      #'  campo, el rake absorbe TODA la corrección de composición demográfica:
+      #'  factores fuera del umbral señalan un campo desbalanceado (revisar pases
+      #'  de horario) y disparan la varianza de las estimaciones.
       extraer_diseno = function(respuestas, marco_muestral, tipo_encuesta, sin_peso, rake,
-                                permitir_sin_conglomerados = FALSE){
+                                permitir_sin_conglomerados = FALSE,
+                                umbral_rake = c(0.5, 2)){
         if(sin_peso){
           self$diseno <- survey::svydesign(
             ids=~1,
@@ -167,6 +173,33 @@ Muestra <-
             pobG <- pob %>% count(rango_edad, wt = value, name = "Freq")
             pobS<- pob %>% count(sexo, wt = value, name = "Freq")
             self$diseno <- survey::rake(diseno, list(~rango_edad, ~sexo), list(pobG, pobS))
+
+            # Monitoreo de los factores de ajuste del rake: sin cuotas en
+            # campo, el rake carga toda la corrección de composición y su
+            # costo es varianza (deff ~ 1 + CV^2 de los pesos). Se normaliza
+            # por la mediana para aislar la COMPOSICIÓN: el reescalado
+            # uniforme de nivel (suma de pesos -> total poblacional del
+            # marco) no es señal de desbalance
+            factor_rake <- as.numeric(stats::weights(self$diseno)) /
+              as.numeric(stats::weights(diseno))
+            factor_rake <- factor_rake / stats::median(factor_rake)
+            message(sprintf(
+              "Factores de ajuste del rake: min %.2f | mediana %.2f | max %.2f.",
+              min(factor_rake), stats::median(factor_rake), max(factor_rake)
+            ))
+            if(min(factor_rake) < umbral_rake[1] || max(factor_rake) > umbral_rake[2]){
+              warning(sprintf(
+                paste0(
+                  "Factores de rake fuera del umbral [%.2f, %.2f] ",
+                  "(min %.2f, max %.2f): la composición del campo se desvía ",
+                  "mucho de los márgenes poblacionales. Sin cuotas, esta es la ",
+                  "señal para revisar los pases de horario/cobertura del ",
+                  "levantamiento; los pesos extremos inflan la varianza de ",
+                  "todas las estimaciones."
+                ),
+                umbral_rake[1], umbral_rake[2], min(factor_rake), max(factor_rake)
+              ), call. = FALSE)
+            }
           } else{
             self$diseno <- diseno
           }

--- a/R/clase_muestra.R
+++ b/R/clase_muestra.R
@@ -83,7 +83,15 @@ Muestra <-
       #'  se asume equiprobable.
       #' @param rake `LOGICAL` Parámetro heredado de la clase encuesta. Determina la postestratificacion
       #'  por edad y sexo.
-      extraer_diseno = function(respuestas, marco_muestral, tipo_encuesta, sin_peso, rake){
+      #' @param permitir_sin_conglomerados `LOGICAL`. Si el diseño con conglomerados
+      #'  no puede construirse, el default (`FALSE`) detiene con un error informativo:
+      #'  un diseño sin conglomerados ignora la correlación intraclase de las
+      #'  entrevistas de una misma sección/manzana y subestima los errores
+      #'  estándar (~25% medido en Chihuahua Ene-2026). Usa `TRUE` solo como
+      #'  decisión consciente del analista; se emite un warning y el diseño se
+      #'  construye estratificado sin conglomerados.
+      extraer_diseno = function(respuestas, marco_muestral, tipo_encuesta, sin_peso, rake,
+                                permitir_sin_conglomerados = FALSE){
         if(sin_peso){
           self$diseno <- survey::svydesign(
             ids=~1,
@@ -101,7 +109,27 @@ Muestra <-
             ,T)
 
           diseno <- if("try-error" %in% class(r)){
-            message("Se intenta muestreo estratificado por estrato. Faltan unidades a muestrear.")
+            if(!permitir_sin_conglomerados){
+              stop(
+                "No se pudo construir el diseño muestral CON conglomerados (",
+                trimws(conditionMessage(attr(r, "condition"))),
+                "). Un diseño sin conglomerados (ids = ~1) ignora la ",
+                "correlación intraclase por sección/manzana y subestima los ",
+                "errores estándar de todo el estudio. Revisa las columnas ",
+                "cluster_*/fpc_*/strata_* del snapshot (NAs en fpc suelen ",
+                "venir de joins vacíos contra el plan muestral); si decides ",
+                "degradar el diseño a propósito, usa ",
+                "permitir_sin_conglomerados = TRUE.",
+                call. = FALSE
+              )
+            }
+            warning(
+              "Diseño construido SIN conglomerados por decisión explícita ",
+              "(permitir_sin_conglomerados = TRUE): los errores estándar ",
+              "quedarán subestimados al ignorar la correlación intraclase ",
+              "por sección/manzana.",
+              call. = FALSE
+            )
             out <- survey::svydesign(
               pps="brewer",
               ids = ~1,

--- a/man/Auditoria.Rd
+++ b/man/Auditoria.Rd
@@ -8,62 +8,63 @@ A short description...
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Auditoria-new}{\code{Auditoria$new()}}
-\item \href{#method-Auditoria-run_app}{\code{Auditoria$run_app()}}
-\item \href{#method-Auditoria-subir_app}{\code{Auditoria$subir_app()}}
-\item \href{#method-Auditoria-clone}{\code{Auditoria$clone()}}
-}
+  \itemize{
+    \item \href{#method-Auditoria-initialize}{\code{Auditoria$new()}}
+    \item \href{#method-Auditoria-run_app}{\code{Auditoria$run_app()}}
+    \item \href{#method-Auditoria-subir_app}{\code{Auditoria$subir_app()}}
+    \item \href{#method-Auditoria-clone}{\code{Auditoria$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Auditoria-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Auditoria-new}{}}}
-\subsection{Method \code{new()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Auditoria$new(encuesta, tipo_encuesta, dir = "auditoria")}\if{html}{\out{</div>}}
+\if{html}{\out{<a id="method-Auditoria-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Auditoria-initialize}{}}}
+\subsection{\code{Auditoria$new()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Auditoria$new(encuesta, tipo_encuesta, dir = "auditoria")}
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{dir}}{}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Auditoria-run_app"></a>}}
 \if{latex}{\out{\hypertarget{method-Auditoria-run_app}{}}}
-\subsection{Method \code{run_app()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Auditoria$run_app()}\if{html}{\out{</div>}}
+\subsection{\code{Auditoria$run_app()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Auditoria$run_app()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Auditoria-subir_app"></a>}}
 \if{latex}{\out{\hypertarget{method-Auditoria-subir_app}{}}}
-\subsection{Method \code{subir_app()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Auditoria$subir_app(...)}\if{html}{\out{</div>}}
+\subsection{\code{Auditoria$subir_app()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Auditoria$subir_app(...)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Auditoria-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Auditoria-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Auditoria$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Auditoria$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Auditoria$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Cruce.Rd
+++ b/man/Cruce.Rd
@@ -8,76 +8,75 @@ La clase \code{Cruce} contiene los métodos necesarios para producir los resulta
 relacionados de crucar dos o más variables.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{encuesta}}{Clase de jerarquía superior. Se requiere para extraer el diseno de la encuesta.}
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{encuesta}}{Clase de jerarquía superior. Se requiere para extraer el diseno de la encuesta.}
 
-\item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey} relacionado con el diseno de la
+    \item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey} relacionado con el diseno de la
 encuesta.}
 
-\item{\code{diccionario}}{Diccionario de procesamiento de la encuesta.}
+    \item{\code{diccionario}}{Diccionario de procesamiento de la encuesta.}
 
-\item{\code{tema}}{Objeto tipo \link{theme} de la paquetería \link{ggplot2}}
+    \item{\code{tema}}{Objeto tipo \link[ggplot2:theme]{theme} de la paquetería \link[ggplot2:ggplot2]{ggplot2}}
 
-\item{\code{graficadas}}{Campo heredado por la clase \code{Resultados}.}
-}
-\if{html}{\out{</div>}}
+    \item{\code{graficadas}}{Campo heredado por la clase \code{Resultados}.}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Cruce-new}{\code{Cruce$new()}}
-\item \href{#method-Cruce-bloques}{\code{Cruce$bloques()}}
-\item \href{#method-Cruce-lineas}{\code{Cruce$lineas()}}
-\item \href{#method-Cruce-lolipop_diferencias}{\code{Cruce$lolipop_diferencias()}}
-\item \href{#method-Cruce-sankey_categorica}{\code{Cruce$sankey_categorica()}}
-\item \href{#method-Cruce-tabla_votoCruzado}{\code{Cruce$tabla_votoCruzado()}}
-\item \href{#method-Cruce-clone}{\code{Cruce$clone()}}
-}
+  \itemize{
+    \item \href{#method-Cruce-initialize}{\code{Cruce$new()}}
+    \item \href{#method-Cruce-bloques}{\code{Cruce$bloques()}}
+    \item \href{#method-Cruce-lineas}{\code{Cruce$lineas()}}
+    \item \href{#method-Cruce-lolipop_diferencias}{\code{Cruce$lolipop_diferencias()}}
+    \item \href{#method-Cruce-sankey_categorica}{\code{Cruce$sankey_categorica()}}
+    \item \href{#method-Cruce-tabla_votoCruzado}{\code{Cruce$tabla_votoCruzado()}}
+    \item \href{#method-Cruce-clone}{\code{Cruce$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Cruce-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Cruce-new}{}}}
-\subsection{Method \code{new()}}{
-Define los insumos necesarios para preparar los métodos que producen los resultados
+\if{html}{\out{<a id="method-Cruce-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Cruce-initialize}{}}}
+\subsection{\code{Cruce$new()}}{
+  Define los insumos necesarios para preparar los métodos que producen los resultados
 entre dos o más variables.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cruce$new(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cruce$new(
   encuesta = NULL,
   diseno = NULL,
   diccionario = NULL,
   tema,
   graficadas = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{encuesta}}{Clase de jerarquía superior. Es el formato de la paquetería \code{encuestar}. Contiene
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{encuesta}}{Clase de jerarquía superior. Es el formato de la paquetería \code{encuestar}. Contiene
 el diseno muestral de la encuesta.}
-
-\item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey}. No se espera que los parametros
+      \item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey}. No se espera que los parametros
 \code{encuesta} y \code{diseno} sean no nullos. El segundo sobreescribe el primero.}
-
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-
-\item{\code{tema}}{Objeto tipo \link{theme} de la paquetería \link{ggplot2}.}
-
-\item{\code{graficadas}}{Parametro heredado de la clase \code{Resultados}.}
+      \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+      \item{\code{tema}}{Objeto tipo \link[ggplot2:theme]{theme} de la paquetería \link[ggplot2:ggplot2]{ggplot2}.}
+      \item{\code{graficadas}}{Parametro heredado de la clase \code{Resultados}.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Cruce-bloques"></a>}}
 \if{latex}{\out{\hypertarget{method-Cruce-bloques}{}}}
-\subsection{Method \code{bloques()}}{
-Calcula el cruce entre dos variables donde una de las dos es binaria. Visualiza
+\subsection{\code{Cruce$bloques()}}{
+  Calcula el cruce entre dos variables donde una de las dos es binaria. Visualiza
 los resultados usando \code{\link[treemapify:geom_treemap]{treemapify::geom_treemap()}}. El método también funciona para casos
 en que la variable principal no es binaria pero no se recomienda su uso.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cruce$bloques(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cruce$bloques(
   variable_principal,
   variable_secundaria,
   colores_variable_secundaria,
@@ -86,45 +85,40 @@ en que la variable principal no es binaria pero no se recomienda su uso.
   linea_grosor = 2,
   linea_color = "white",
   na_rm = TRUE
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{variable_principal}}{Valor tipo caracter que indica la variable principal que idealmente
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{variable_principal}}{Valor tipo caracter que indica la variable principal que idealmente
 es binaria.}
-
-\item{\code{variable_secundaria}}{Valor tipo caracter que indica la variable secundaria. No se recomienda
+      \item{\code{variable_secundaria}}{Valor tipo caracter que indica la variable secundaria. No se recomienda
 varaibles tipo numérico.}
-
-\item{\code{colores_variable_secundaria}}{Vector que identifica los colores asociados a los valores
-únicos de la variable secundaria. Es el argumento \link{values} de la función \code{\link[ggplot2:scale_manual]{ggplot2::scale_fill_manual()}}.}
-
-\item{\code{filter_variable_secundaria}}{Valor tipo caracter. Operación de identidad que se aplica como filtro entre los
+      \item{\code{colores_variable_secundaria}}{Vector que identifica los colores asociados a los valores
+únicos de la variable secundaria. Es el argumento \link{values} de la función \code{\link[ggplot2:scale_fill_manual]{ggplot2::scale_fill_manual()}}.}
+      \item{\code{filter_variable_secundaria}}{Valor tipo caracter. Operación de identidad que se aplica como filtro entre los
 resultados de la variable secundaria.}
-
-\item{\code{vartype}}{Parametro de \code{\link[srvyr:survey_mean]{srvyr::survey_mean()}} que reporta la variabilidad de la estimacion}
-
-\item{\code{linea_grosor}}{Valor tipo entero. Determina el grosor de la linea que divide a los
+      \item{\code{vartype}}{Parametro de \code{\link[srvyr:survey_mean]{srvyr::survey_mean()}} que reporta la variabilidad de la estimacion}
+      \item{\code{linea_grosor}}{Valor tipo entero. Determina el grosor de la linea que divide a los
 'subbloques' dentro de cada grupo.}
-
-\item{\code{linea_color}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color de la linea que
+      \item{\code{linea_color}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color de la linea que
 separa a los 'subbloques'}
+      \item{\code{na_rm}}{\code{LOGICAL}. En el cálculo de estimaciones, se omiten los valores nulos.}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{na_rm}}{\code{LOGICAL}. En el cálculo de estimaciones, se omiten los valores nulos.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Cruce-lineas"></a>}}
 \if{latex}{\out{\hypertarget{method-Cruce-lineas}{}}}
-\subsection{Method \code{lineas()}}{
-Calcula el cruce entre dos variables no necesariamente binarias y muestra el
-resultado usando \code{\link[ggplot2:geom_path]{ggplot2::geom_line()}} para cada valor de la variable secundaria.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cruce$lineas(
+\subsection{\code{Cruce$lineas()}}{
+  Calcula el cruce entre dos variables no necesariamente binarias y muestra el
+resultado usando \code{\link[ggplot2:geom_line]{ggplot2::geom_line()}} para cada valor de la variable secundaria.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cruce$lineas(
   variable_principal,
   variable_secundaria,
   orden_variable_principal,
@@ -139,63 +133,52 @@ resultado usando \code{\link[ggplot2:geom_path]{ggplot2::geom_line()}} para cada
   size_text_y = 14,
   size_text_legend = 14,
   na_rm = TRUE
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{variable_principal}}{Valor tipo caracter que indica la variable principal. Las categorías
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{variable_principal}}{Valor tipo caracter que indica la variable principal. Las categorías
 se muestran en el eje x.}
-
-\item{\code{variable_secundaria}}{Valor tipo caracter que indica la variable secundaria.}
-
-\item{\code{orden_variable_principal}}{Vector tipo caracter. Contiene los valores únicos de la
+      \item{\code{variable_secundaria}}{Valor tipo caracter que indica la variable secundaria.}
+      \item{\code{orden_variable_principal}}{Vector tipo caracter. Contiene los valores únicos de la
 variable principal en forma ordenada.}
-
-\item{\code{valores_variable_secundaria}}{Vector tipo caracter  que contiene los valores de interés
+      \item{\code{valores_variable_secundaria}}{Vector tipo caracter  que contiene los valores de interés
 de la variable secundaria.}
-
-\item{\code{colores_variable_secundaria}}{Vector que identifica los colores asociados a los valores
-únicos de la variable secundaria. Es el argumento \link{values} de la función \code{\link[ggplot2:scale_manual]{ggplot2::scale_fill_manual()}}.}
-
-\item{\code{limits}}{Dupla tipo numérica. Son los posibles valores mínimos y máximos posibles asociados
+      \item{\code{colores_variable_secundaria}}{Vector que identifica los colores asociados a los valores
+únicos de la variable secundaria. Es el argumento \link{values} de la función \code{\link[ggplot2:scale_fill_manual]{ggplot2::scale_fill_manual()}}.}
+      \item{\code{limits}}{Dupla tipo numérica. Son los posibles valores mínimos y máximos posibles asociados
 a la pregunta que representa la variable.}
-
-\item{\code{wrap_x}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
-Aplica la función \code{\link[=str_wrap]{str_wrap()}} de la paquetería \link{stringr} a las labels del eje x.}
-
-\item{\code{wrap_legend}}{Valor tipo entero. Reduce o aumenta la longitud de las \code{legends} del gráfico}
-
-\item{\code{text_nudge_y}}{Valor real. Parámetro \link{nudge_y} de la función \link{geom_text} aplicado a la
+      \item{\code{wrap_x}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
+Aplica la función \code{\link[stringr:str_wrap]{str_wrap()}} de la paquetería \link[stringr:stringr]{stringr} a las labels del eje x.}
+      \item{\code{wrap_legend}}{Valor tipo entero. Reduce o aumenta la longitud de las \code{legends} del gráfico}
+      \item{\code{text_nudge_y}}{Valor real. Parámetro \link{nudge_y} de la función \link[ggplot2:geom_text]{geom_text} aplicado a la
 función \code{\link[ggrepel:geom_text_repel]{ggrepel::geom_text_repel()}}.}
-
-\item{\code{size_text}}{Valor entero. Determina el tamano del dentro del gráfico. Es el parámetro
-\link{size} de la función \code{\link[ggrepel:geom_text_repel]{ggrepel::geom_text_repel()}}.}
-
-\item{\code{size_text_x}}{Valor entero. Determina el tamano del dentro del eje x. Es el parámetro
-\link{size} de la función \code{\link[ggplot2:element]{ggplot2::element_text()}} aplicado a \link{axis.text.x}}
-
-\item{\code{size_text_y}}{Valor entero. Determina el tamano del dentro del eje y. Es el parámetro
-\link{size} de la función \code{\link[ggplot2:element]{ggplot2::element_text()}} aplicado a \link{axis.text.y}}
-
-\item{\code{size_text_legend}}{Valor entero. Determina el tamano del dentro de las legends Es el parámetro
-\link{size} de la función \code{\link[ggplot2:element]{ggplot2::element_text()}} aplicado a \link{axis.text.legend}}
-
-\item{\code{na_rm}}{\code{LOGICAL}. En el cálculo de estimaciones, se omiten los valores nulos.}
+      \item{\code{size_text}}{Valor entero. Determina el tamano del dentro del gráfico. Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggrepel:geom_text_repel]{ggrepel::geom_text_repel()}}.}
+      \item{\code{size_text_x}}{Valor entero. Determina el tamano del dentro del eje x. Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:element_text]{ggplot2::element_text()}} aplicado a \link{axis.text.x}}
+      \item{\code{size_text_y}}{Valor entero. Determina el tamano del dentro del eje y. Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:element_text]{ggplot2::element_text()}} aplicado a \link{axis.text.y}}
+      \item{\code{size_text_legend}}{Valor entero. Determina el tamano del dentro de las legends Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:element_text]{ggplot2::element_text()}} aplicado a \link{axis.text.legend}}
+      \item{\code{na_rm}}{\code{LOGICAL}. En el cálculo de estimaciones, se omiten los valores nulos.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Cruce-lolipop_diferencias"></a>}}
 \if{latex}{\out{\hypertarget{method-Cruce-lolipop_diferencias}{}}}
-\subsection{Method \code{lolipop_diferencias()}}{
-Calcula el cruce entre dos variables categoricas donde la primera o principal
+\subsection{\code{Cruce$lolipop_diferencias()}}{
+  Calcula el cruce entre dos variables categoricas donde la primera o principal
 es binaria, filtra los valores de interés de la segunda variable y muestra las diferencias
 relativas a la primera en una gráfica tipo lolipop.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cruce$lolipop_diferencias(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cruce$lolipop_diferencias(
   variable_principal,
   variables_secundarias,
   filtro_variables_secundarias,
@@ -217,121 +200,100 @@ relativas a la primera en una gráfica tipo lolipop.
   traslape = F,
   limite_dif_pct = 0.02,
   ajuste_pos = 0.02
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{variable_principal}}{Valor tipo caracter que indica la variable principal. Las categorías
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{variable_principal}}{Valor tipo caracter que indica la variable principal. Las categorías
 se muestran en el eje y.}
-
-\item{\code{variables_secundarias}}{Valor tipo caracter que indica las variables secundarias.}
-
-\item{\code{filtro_variables_secundarias}}{Valor tipo caracter. Valor en común entre las variables
+      \item{\code{variables_secundarias}}{Valor tipo caracter que indica las variables secundarias.}
+      \item{\code{filtro_variables_secundarias}}{Valor tipo caracter. Valor en común entre las variables
 secundarias y que es de interés para mostrar resultados.}
-
-\item{\code{orden_variablePrincipal}}{Vector tipo caracter. Contiene los valores únicos de la
+      \item{\code{orden_variablePrincipal}}{Vector tipo caracter. Contiene los valores únicos de la
 variable principal en forma ordenada.}
-
-\item{\code{colores_variables_secundarias}}{Vector que identifica los colores asociados a los valores
-únicos de las variables secundaria. Es el argumento \link{values} de la función \code{\link[ggplot2:scale_manual]{ggplot2::scale_fill_manual()}}.}
-
-\item{\code{caption}}{Valor tipo caracter. Es el \link{caption} del gráfico.}
-
-\item{\code{nudge_x}}{Valor real. Parámetro \link{nudge_x} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
-
-\item{\code{size_geom_text}}{Valor entero. Determina el tamano del dentro del gráfico. Es el parámetro
-\link{size} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
-
-\item{\code{invertir_variables}}{\code{LOGICAL}. Determina si las variables principal y secundarias se
+      \item{\code{colores_variables_secundarias}}{Vector que identifica los colores asociados a los valores
+únicos de las variables secundaria. Es el argumento \link{values} de la función \code{\link[ggplot2:scale_fill_manual]{ggplot2::scale_fill_manual()}}.}
+      \item{\code{caption}}{Valor tipo caracter. Es el \link{caption} del gráfico.}
+      \item{\code{nudge_x}}{Valor real. Parámetro \link{nudge_x} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
+      \item{\code{size_geom_text}}{Valor entero. Determina el tamano del dentro del gráfico. Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
+      \item{\code{invertir_variables}}{\code{LOGICAL}. Determina si las variables principal y secundarias se
 invierten en el gráfico.}
-
-\item{\code{vartype}}{Parametro de \code{\link[srvyr:survey_mean]{srvyr::survey_mean()}} que reporta la variabilidad de la estimacion}
-
-\item{\code{limits}}{Dupla tipo numérica. Son los posibles valores mínimos y máximos posibles asociados
+      \item{\code{vartype}}{Parametro de \code{\link[srvyr:survey_mean]{srvyr::survey_mean()}} que reporta la variabilidad de la estimacion}
+      \item{\code{limits}}{Dupla tipo numérica. Son los posibles valores mínimos y máximos posibles asociados
 a la pregunta que representa la variable.}
-
-\item{\code{wrap_y}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje y.
-Aplica la función \code{\link[=str_wrap]{str_wrap()}} de la paquetería \link{stringr} a las labels del eje y.}
-
-\item{\code{wrap_caption}}{Valor tipo entero. Reduce o aumenta la longitud del texto mostrado en
+      \item{\code{wrap_y}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje y.
+Aplica la función \code{\link[stringr:str_wrap]{str_wrap()}} de la paquetería \link[stringr:stringr]{stringr} a las labels del eje y.}
+      \item{\code{wrap_caption}}{Valor tipo entero. Reduce o aumenta la longitud del texto mostrado en
 el caption.}
-
-\item{\code{size_text_x}}{Valor entero. Determina el tamano del dentro del eje x. Es el parámetro
-\link{size} de la función \code{\link[ggplot2:element]{ggplot2::element_text()}} aplicado a \link{axis.text.x}}
-
-\item{\code{size_text_y}}{Valor entero. Determina el tamano del dentro del eje y. Es el parámetro
-\link{size} de la función \code{\link[ggplot2:element]{ggplot2::element_text()}} aplicado a \link{axis.text.y}}
-
-\item{\code{size_text_caption}}{Valor entero. Determina el tamano del dentro de las legends Es el parámetro
-\link{size} de la función \code{\link[ggplot2:element]{ggplot2::element_text()}} aplicado a \link{axis.text.caption}}
-
-\item{\code{size_text_legend}}{Valor entero. Determina el tamano del dentro de las legends Es el parámetro
-\link{size} de la función \code{\link[ggplot2:element]{ggplot2::element_text()}} aplicado a \link{axis.text.legend}}
-
-\item{\code{ver_diferencias}}{\code{LOGICAL}. Determina si se muestran las diferencias en puntos porcentuales
+      \item{\code{size_text_x}}{Valor entero. Determina el tamano del dentro del eje x. Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:element_text]{ggplot2::element_text()}} aplicado a \link{axis.text.x}}
+      \item{\code{size_text_y}}{Valor entero. Determina el tamano del dentro del eje y. Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:element_text]{ggplot2::element_text()}} aplicado a \link{axis.text.y}}
+      \item{\code{size_text_caption}}{Valor entero. Determina el tamano del dentro de las legends Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:element_text]{ggplot2::element_text()}} aplicado a \link{axis.text.caption}}
+      \item{\code{size_text_legend}}{Valor entero. Determina el tamano del dentro de las legends Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:element_text]{ggplot2::element_text()}} aplicado a \link{axis.text.legend}}
+      \item{\code{ver_diferencias}}{\code{LOGICAL}. Determina si se muestran las diferencias en puntos porcentuales
 dentro del gráfico.}
-
-\item{\code{traslape}}{Valor bopoleano. En caso de ser TRUE, realiza un factor de ajuste para los porcentajes presentados por \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.
+      \item{\code{traslape}}{Valor bopoleano. En caso de ser TRUE, realiza un factor de ajuste para los porcentajes presentados por \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.
 Solo afecta a los valores cuya diferencia máxima y mínima se menor que el factor de tolerancia \link{limite_dif_pct}.  Por defecto tiene valor FALSE.}
-
-\item{\code{limite_dif_pct}}{Valor de tipo decimal. Es el factor o nivel de tolerencia para la diferencia entre dos puntos
+      \item{\code{limite_dif_pct}}{Valor de tipo decimal. Es el factor o nivel de tolerencia para la diferencia entre dos puntos
 que al graficar sus porcentajes tienen un nivel de traslape. Solo se efectua si \link{traslape} es TRUE. Por defecto su valor es 0.02.}
-
-\item{\code{ajuste_pos}}{Valor de tipo decimal. Es el factor de ajuste de posición que los porcentajes
+      \item{\code{ajuste_pos}}{Valor de tipo decimal. Es el factor de ajuste de posición que los porcentajes
 graficados tomarán en caso de traslaparse. El porcentaje menor se despalzará la izquierda, y el mayor a la derecha. Solo se efectua si \link{traslape} es TRUE. Por defecto su valor es 0.02.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Cruce-sankey_categorica"></a>}}
 \if{latex}{\out{\hypertarget{method-Cruce-sankey_categorica}{}}}
-\subsection{Method \code{sankey_categorica()}}{
-Muestra las proporciones de individuos correspondientes a valores unicos entre
+\subsection{\code{Cruce$sankey_categorica()}}{
+  Muestra las proporciones de individuos correspondientes a valores unicos entre
 dos variables en una gráfica tipo \code{sankey}
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cruce$sankey_categorica(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cruce$sankey_categorica(
   variables = NULL,
   colores,
   size_text_cat = 6,
   width_text = 15,
   omitir_valores_variable1 = NULL,
   omitir_valores_variable2 = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{variables}}{Vector tipo caracter que contiene las dos variables a visualizar.}
-
-\item{\code{colores}}{Vector que identifica los colores asociados a los valores únicos de las variables
-Es el argumento \link{values} de la función \code{\link[ggplot2:scale_manual]{ggplot2::scale_fill_manual()}} y \code{\link[ggplot2:scale_manual]{ggplot2::scale_color_manual()}}}
-
-\item{\code{size_text_cat}}{Parametro \link{size} de la funcion \code{\link[ggsankey:geom_sankey_label]{ggsankey::geom_sankey_text()}} que determina
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{variables}}{Vector tipo caracter que contiene las dos variables a visualizar.}
+      \item{\code{colores}}{Vector que identifica los colores asociados a los valores únicos de las variables
+Es el argumento \link{values} de la función \code{\link[ggplot2:scale_fill_manual]{ggplot2::scale_fill_manual()}} y \code{\link[ggplot2:scale_color_manual]{ggplot2::scale_color_manual()}}}
+      \item{\code{size_text_cat}}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggsankey:geom_sankey_text]{ggsankey::geom_sankey_text()}} que determina
 el tamano del texto de las etiquetas en cada nodo del gráfico.}
-
-\item{\code{width_text}}{Valor tipo entero. Reduce o aumenta la longitud del texto mostrado en las etiquetas}
-
-\item{\code{omitir_valores_variable1}}{Vector tipo caracter. Valores únicos de la primer variable
+      \item{\code{width_text}}{Valor tipo entero. Reduce o aumenta la longitud del texto mostrado en las etiquetas}
+      \item{\code{omitir_valores_variable1}}{Vector tipo caracter. Valores únicos de la primer variable
 que se omiten de los resultados.}
-
-\item{\code{omitir_valores_variable2}}{Vector tipo caracter. Valores únicos de la segunda variable
+      \item{\code{omitir_valores_variable2}}{Vector tipo caracter. Valores únicos de la segunda variable
 que se omiten de los resultados.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Cruce-tabla_votoCruzado"></a>}}
 \if{latex}{\out{\hypertarget{method-Cruce-tabla_votoCruzado}{}}}
-\subsection{Method \code{tabla_votoCruzado()}}{
-Muestra las proporciones de individuos correspondientes a valores unicos entre
+\subsection{\code{Cruce$tabla_votoCruzado()}}{
+  Muestra las proporciones de individuos correspondientes a valores unicos entre
 dos variables en una tabla renderizada mediante la paquetería \link{flextable}.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cruce$tabla_votoCruzado(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cruce$tabla_votoCruzado(
   var1,
   var2,
   filtro_var2 = NULL,
@@ -342,57 +304,51 @@ dos variables en una tabla renderizada mediante la paquetería \link{flextable}.
   size_text_body = 14,
   salto = 20,
   na_rm = TRUE
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{var1}}{Valor tipo caracter. Es el nombre de la variable principal del cruce.}
-
-\item{\code{var2}}{Valor tipo caracter. Nombre de la variable secundaria del cruce.}
-
-\item{\code{filtro_var2}}{Vector tiopo caracter. Son los valores únicos de la segunda variable que
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{var1}}{Valor tipo caracter. Es el nombre de la variable principal del cruce.}
+      \item{\code{var2}}{Valor tipo caracter. Nombre de la variable secundaria del cruce.}
+      \item{\code{filtro_var2}}{Vector tiopo caracter. Son los valores únicos de la segunda variable que
 se omiten de los resultados.}
-
-\item{\code{etiquetas}}{Dupla ordenada tipo caracter. Nombres de las variables para mostrar en el
+      \item{\code{etiquetas}}{Dupla ordenada tipo caracter. Nombres de las variables para mostrar en el
 resultado final.}
-
-\item{\code{colores_var1}}{Vector que identifica los colores asociados a los valores únicos de la
+      \item{\code{colores_var1}}{Vector que identifica los colores asociados a los valores únicos de la
 primer variable.}
-
-\item{\code{colores_var2}}{Vector que identifica los colores asociados a los valores únicos de la
+      \item{\code{colores_var2}}{Vector que identifica los colores asociados a los valores únicos de la
 segunda variable.}
-
-\item{\code{size_text_header}}{Valor tipo entero. Determina el tamano del texto en el encabezado
+      \item{\code{size_text_header}}{Valor tipo entero. Determina el tamano del texto en el encabezado
 de la tabla.}
-
-\item{\code{size_text_body}}{Valor tipo entero. Determina el tamano del texto en el cuerpo de la
+      \item{\code{size_text_body}}{Valor tipo entero. Determina el tamano del texto en el cuerpo de la
 tabla.}
-
-\item{\code{salto}}{Valor tipo entero. Reduce o aumenta la longitud del texto mostrado en
+      \item{\code{salto}}{Valor tipo entero. Reduce o aumenta la longitud del texto mostrado en
 el caption.}
+      \item{\code{na_rm}}{\code{LOGICAL}. En el cálculo de estimaciones, se omiten los valores nulos.}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{na_rm}}{\code{LOGICAL}. En el cálculo de estimaciones, se omiten los valores nulos.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Cruce-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Cruce-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cruce$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Cruce$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cruce$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Cuestionario.Rd
+++ b/man/Cuestionario.Rd
@@ -9,102 +9,111 @@ acuerdo a las necesidades de la paquetería, el diccionario usado en procesamien
 de resultados de la encuesta.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{documento}}{Actualmente contiene el diccionario usado en procesamiento y producción de
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{documento}}{Actualmente contiene el diccionario usado en procesamiento y producción de
 resultados}
 
-\item{\code{aprobado}}{Campo en desuso.}
+    \item{\code{aprobado}}{Campo en desuso.}
 
-\item{\code{diccionario}}{Anteriormente el diccionario era producido al procesar el campo  \code{documento}.
+    \item{\code{diccionario}}{Anteriormente el diccionario era producido al procesar el campo  \code{documento}.
 Este proceso ya no es necesario.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Cuestionario-new}{\code{Cuestionario$new()}}
-\item \href{#method-Cuestionario-aprobar}{\code{Cuestionario$aprobar()}}
-\item \href{#method-Cuestionario-checar_pregunta}{\code{Cuestionario$checar_pregunta()}}
-\item \href{#method-Cuestionario-resumen}{\code{Cuestionario$resumen()}}
-\item \href{#method-Cuestionario-clone}{\code{Cuestionario$clone()}}
-}
+  \itemize{
+    \item \href{#method-Cuestionario-initialize}{\code{Cuestionario$new()}}
+    \item \href{#method-Cuestionario-aprobar}{\code{Cuestionario$aprobar()}}
+    \item \href{#method-Cuestionario-checar_pregunta}{\code{Cuestionario$checar_pregunta()}}
+    \item \href{#method-Cuestionario-resumen}{\code{Cuestionario$resumen()}}
+    \item \href{#method-Cuestionario-clone}{\code{Cuestionario$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Cuestionario-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Cuestionario-new}{}}}
-\subsection{Method \code{new()}}{
-Recibe y establece el diccionario de procesamiento
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cuestionario$new(documento, patron)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{documento}}{\code{\link[=tibble]{tibble()}} qque contiene el diccionario (codebook) del cuestionario
+\if{html}{\out{<a id="method-Cuestionario-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Cuestionario-initialize}{}}}
+\subsection{\code{Cuestionario$new()}}{
+  Recibe y establece el diccionario de procesamiento
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cuestionario$new(documento, patron)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{documento}}{\code{\link[tibble:tibble]{tibble()}} qque contiene el diccionario (codebook) del cuestionario
 aplicado en la encuesta.}
-
-\item{\code{patron}}{Valor tipo caracter que se omitirán de las preguntas.
+      \item{\code{patron}}{Valor tipo caracter que se omitirán de las preguntas.
 Por ejmplo "Rotar respuestas".}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Cuestionario-aprobar"></a>}}
 \if{latex}{\out{\hypertarget{method-Cuestionario-aprobar}{}}}
-\subsection{Method \code{aprobar()}}{
-En desuso.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cuestionario$aprobar()}\if{html}{\out{</div>}}
+\subsection{\code{Cuestionario$aprobar()}}{
+  En desuso.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cuestionario$aprobar()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Cuestionario-checar_pregunta"></a>}}
 \if{latex}{\out{\hypertarget{method-Cuestionario-checar_pregunta}{}}}
-\subsection{Method \code{checar_pregunta()}}{
-En desuso.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cuestionario$checar_pregunta(pregunta)}\if{html}{\out{</div>}}
+\subsection{\code{Cuestionario$checar_pregunta()}}{
+  En desuso.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cuestionario$checar_pregunta(pregunta)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{pregunta}}{En desuso}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{pregunta}}{En desuso}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Cuestionario-resumen"></a>}}
 \if{latex}{\out{\hypertarget{method-Cuestionario-resumen}{}}}
-\subsection{Method \code{resumen()}}{
-Visualiza el diccionario para mostrar extensión de cada bloque y sus
+\subsection{\code{Cuestionario$resumen()}}{
+  Visualiza el diccionario para mostrar extensión de cada bloque y sus
 posibles respuestas a cada pregunta
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cuestionario$resumen()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cuestionario$resumen()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Cuestionario-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Cuestionario-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cuestionario$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Cuestionario$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Cuestionario$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Descriptiva.Rd
+++ b/man/Descriptiva.Rd
@@ -9,78 +9,77 @@ más básicos relacionados a la encuesta como graficas de barras de estimaciones
 o graficas tipo \code{gauge} que muestan el porcentaje de uno de los valores una variable binaria.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{encuesta}}{Clase de jerarquía superior. Se requiere para extraer el diseno de la encuesta.}
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{encuesta}}{Clase de jerarquía superior. Se requiere para extraer el diseno de la encuesta.}
 
-\item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey} relacionado con el diseno de la
+    \item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey} relacionado con el diseno de la
 encuesta.}
 
-\item{\code{diccionario}}{Diccionario de procesamiento de la encuesta.}
+    \item{\code{diccionario}}{Diccionario de procesamiento de la encuesta.}
 
-\item{\code{tema}}{Objeto tipo \link{theme} de la paquetería \link{ggplot2}}
+    \item{\code{tema}}{Objeto tipo \link[ggplot2:theme]{theme} de la paquetería \link[ggplot2:ggplot2]{ggplot2}}
 
-\item{\code{graficadas}}{Campo heredado por la clase \code{Resultados}.}
-}
-\if{html}{\out{</div>}}
+    \item{\code{graficadas}}{Campo heredado por la clase \code{Resultados}.}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Descriptiva-new}{\code{Descriptiva$new()}}
-\item \href{#method-Descriptiva-barras_categorica}{\code{Descriptiva$barras_categorica()}}
-\item \href{#method-Descriptiva-barras_aspectos}{\code{Descriptiva$barras_aspectos()}}
-\item \href{#method-Descriptiva-barras_multirespuesta}{\code{Descriptiva$barras_multirespuesta()}}
-\item \href{#method-Descriptiva-gauge_numerica}{\code{Descriptiva$gauge_numerica()}}
-\item \href{#method-Descriptiva-gauge_categorica}{\code{Descriptiva$gauge_categorica()}}
-\item \href{#method-Descriptiva-intervalo_numerica}{\code{Descriptiva$intervalo_numerica()}}
-\item \href{#method-Descriptiva-lollipops_categorica}{\code{Descriptiva$lollipops_categorica()}}
-\item \href{#method-Descriptiva-lollipops_multirespuesta}{\code{Descriptiva$lollipops_multirespuesta()}}
-\item \href{#method-Descriptiva-clone}{\code{Descriptiva$clone()}}
-}
+  \itemize{
+    \item \href{#method-Descriptiva-initialize}{\code{Descriptiva$new()}}
+    \item \href{#method-Descriptiva-barras_categorica}{\code{Descriptiva$barras_categorica()}}
+    \item \href{#method-Descriptiva-barras_aspectos}{\code{Descriptiva$barras_aspectos()}}
+    \item \href{#method-Descriptiva-barras_multirespuesta}{\code{Descriptiva$barras_multirespuesta()}}
+    \item \href{#method-Descriptiva-gauge_numerica}{\code{Descriptiva$gauge_numerica()}}
+    \item \href{#method-Descriptiva-gauge_categorica}{\code{Descriptiva$gauge_categorica()}}
+    \item \href{#method-Descriptiva-intervalo_numerica}{\code{Descriptiva$intervalo_numerica()}}
+    \item \href{#method-Descriptiva-lollipops_categorica}{\code{Descriptiva$lollipops_categorica()}}
+    \item \href{#method-Descriptiva-lollipops_multirespuesta}{\code{Descriptiva$lollipops_multirespuesta()}}
+    \item \href{#method-Descriptiva-clone}{\code{Descriptiva$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Descriptiva-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Descriptiva-new}{}}}
-\subsection{Method \code{new()}}{
-Define los insumos necesarios para preparar los métodos que producen los resultados
+\if{html}{\out{<a id="method-Descriptiva-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Descriptiva-initialize}{}}}
+\subsection{\code{Descriptiva$new()}}{
+  Define los insumos necesarios para preparar los métodos que producen los resultados
 más básicos de la paquetería.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Descriptiva$new(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Descriptiva$new(
   encuesta = NULL,
   diseno = NULL,
   diccionario = NULL,
   tema,
   graficadas = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{encuesta}}{Clase de jerarquía superior. Es el formato de la paquetería \code{encuestar}. Contiene
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{encuesta}}{Clase de jerarquía superior. Es el formato de la paquetería \code{encuestar}. Contiene
 el diseno muestral de la encuesta.}
-
-\item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey}. No se espera que los parametros
+      \item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey}. No se espera que los parametros
 \code{encuesta} y \code{diseno} sean no nullos. El segundo sobreescribe el primero.}
-
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-
-\item{\code{tema}}{Objeto tipo \link{theme} de la paquetería \link{ggplot2}.}
-
-\item{\code{graficadas}}{Parametro heredado de la clase \code{Resultados}.}
+      \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+      \item{\code{tema}}{Objeto tipo \link[ggplot2:theme]{theme} de la paquetería \link[ggplot2:ggplot2]{ggplot2}.}
+      \item{\code{graficadas}}{Parametro heredado de la clase \code{Resultados}.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Descriptiva-barras_categorica"></a>}}
 \if{latex}{\out{\hypertarget{method-Descriptiva-barras_categorica}{}}}
-\subsection{Method \code{barras_categorica()}}{
-Calcula las estimaciones de una variable y muestra los resultados en una
+\subsection{\code{Descriptiva$barras_categorica()}}{
+  Calcula las estimaciones de una variable y muestra los resultados en una
 gráfica de barras ordenadas de mayor a menor de forma vertical de acuerdo a las esitmaciones.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Descriptiva$barras_categorica(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Descriptiva$barras_categorica(
   codigo,
   salto = 20,
   porcentajes_fuera = F,
@@ -88,44 +87,41 @@ gráfica de barras ordenadas de mayor a menor de forma vertical de acuerdo a las
   pct_otros = 0.01,
   orden_respuestas = NA,
   text_size = 8
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{codigo}}{Valor tipo caracter. Nombre de la variable que se va a analizar.}
-
-\item{\code{salto}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
-Aplica la función \code{\link[=str_wrap]{str_wrap()}} de la paquetería \link{stringr} a los valores únicos de la
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{codigo}}{Valor tipo caracter. Nombre de la variable que se va a analizar.}
+      \item{\code{salto}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
+Aplica la función \code{\link[stringr:str_wrap]{str_wrap()}} de la paquetería \link[stringr:stringr]{stringr} a los valores únicos de la
 variable de interés.}
-
-\item{\code{porcentajes_fuera}}{\code{LOGICAL}. Visualiza las labels que muestran las estimaciones dentro
+      \item{\code{porcentajes_fuera}}{\code{LOGICAL}. Visualiza las labels que muestran las estimaciones dentro
 o fuera de la barra. Útil para cuando hay muchas categorías.}
-
-\item{\code{desplazar_porcentajes}}{Valor real. Parámetro \link{nudge_y} de la función \link{geom_text}. Aplica
+      \item{\code{desplazar_porcentajes}}{Valor real. Parámetro \link{nudge_y} de la función \link[ggplot2:geom_text]{geom_text}. Aplica
 sólo si \code{porcentajes_fuera} es \code{TRUE}.}
-
-\item{\code{pct_otros}}{Valor real definido entre 0 y 1. A las categorias cuyas estimaciones sean menor
+      \item{\code{pct_otros}}{Valor real definido entre 0 y 1. A las categorias cuyas estimaciones sean menor
 o igual que \code{pct_otros} las agrupa, las suma y las muestra en \code{Otros}.}
-
-\item{\code{orden_respuestas}}{Vector tipo caracter que contiene, de manera ordenada, los valores únicos
+      \item{\code{orden_respuestas}}{Vector tipo caracter que contiene, de manera ordenada, los valores únicos
 de la variable de interés y reordena las barras de la gráfica de barras de acuerdo a ese orden.
 @param text_size Valor tipo entero. Corresponde al tamaño de los porcentajes contenidos en la gráfica de barras.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Descriptiva-barras_aspectos"></a>}}
 \if{latex}{\out{\hypertarget{method-Descriptiva-barras_aspectos}{}}}
-\subsection{Method \code{barras_aspectos()}}{
-Calcula las estimaciones de varias variables cuyos nombres inician con el mismo
+\subsection{\code{Descriptiva$barras_aspectos()}}{
+  Calcula las estimaciones de varias variables cuyos nombres inician con el mismo
 patron de caracteres. Las variables tienen que contener al menos un valor común entre todas.
 El formato esperado de los nombres de las variables son patron_inicial_aspecto1, patron_inicial_aspecto2
 patron_inicial_aspecto3 etc.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Descriptiva$barras_aspectos(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Descriptiva$barras_aspectos(
   patron_inicial,
   aspectos = NULL,
   salto = 20,
@@ -133,188 +129,177 @@ patron_inicial_aspecto3 etc.
   porcentajes_fuera = F,
   desplazar_porcentajes = 0,
   text_size = 8
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{patron_inicial}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{patron_inicial}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
 los nombres de las variables.}
-
-\item{\code{aspectos}}{Vector tipo caracter que identifica a las diferentes variables a procesar. De
+      \item{\code{aspectos}}{Vector tipo caracter que identifica a las diferentes variables a procesar. De
 acuerdo al método, el ejemplo sería c("aspecto1", "aspecto2", "aspecto3").}
-
-\item{\code{salto}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
-Aplica la función \code{\link[=str_wrap]{str_wrap()}} de la paquetería \link{stringr} a las labels del eje x.}
-
-\item{\code{filtro}}{Valor tipo caracter. Operación de identidad que se aplica como filtro entre los
+      \item{\code{salto}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
+Aplica la función \code{\link[stringr:str_wrap]{str_wrap()}} de la paquetería \link[stringr:stringr]{stringr} a las labels del eje x.}
+      \item{\code{filtro}}{Valor tipo caracter. Operación de identidad que se aplica como filtro entre los
 resultados de las variables de interés. Por defecto, la variable que contiene los valores
 únicos se llama "respuesta" por lo que el filtro aplica sobre esa variable muda. por ejemplo
 filtro = "respuesta == 'azul'".}
-
-\item{\code{porcentajes_fuera}}{\code{LOGICAL}. Visualiza las labels que muestran las estimaciones dentro
+      \item{\code{porcentajes_fuera}}{\code{LOGICAL}. Visualiza las labels que muestran las estimaciones dentro
 o fuera de la barra. Útil para cuando hay muchas categorías.}
-
-\item{\code{desplazar_porcentajes}}{Valor real. Parámetro \link{nudge_y} de la función \link{geom_text}. Aplica
+      \item{\code{desplazar_porcentajes}}{Valor real. Parámetro \link{nudge_y} de la función \link[ggplot2:geom_text]{geom_text}. Aplica
 sólo si \code{porcentajes_fuera} es \code{TRUE}.}
+      \item{\code{text_size}}{Valor tipo entero. Corresponde al tamaño de los porcentajes contenidos en la gráfica de barras.}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{text_size}}{Valor tipo entero. Corresponde al tamaño de los porcentajes contenidos en la gráfica de barras.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Descriptiva-barras_multirespuesta"></a>}}
 \if{latex}{\out{\hypertarget{method-Descriptiva-barras_multirespuesta}{}}}
-\subsection{Method \code{barras_multirespuesta()}}{
-Calcula las estimaciones de varias variables cuyos nombres inician con el mismo
+\subsection{\code{Descriptiva$barras_multirespuesta()}}{
+  Calcula las estimaciones de varias variables cuyos nombres inician con el mismo
 patrón de caracteres. Dichas variables representan un conjunto de preguntar multirespuesta.
 Muestra los resultados en un gráfico tipo gráfica de barras.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Descriptiva$barras_multirespuesta(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Descriptiva$barras_multirespuesta(
   patron_inicial,
   salto = 20,
   porcentajes_fuera = F,
   desplazar_porcentajes = 0,
   text_size = 8
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{patron_inicial}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{patron_inicial}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
 los nombres de las variables.}
-
-\item{\code{salto}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
-Aplica la función \code{\link[=str_wrap]{str_wrap()}} de la paquetería \link{stringr} a las labels del eje x.}
-
-\item{\code{porcentajes_fuera}}{\code{LOGICAL}. Visualiza las labels que muestran las estimaciones dentro
+      \item{\code{salto}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
+Aplica la función \code{\link[stringr:str_wrap]{str_wrap()}} de la paquetería \link[stringr:stringr]{stringr} a las labels del eje x.}
+      \item{\code{porcentajes_fuera}}{\code{LOGICAL}. Visualiza las labels que muestran las estimaciones dentro
 o fuera de la barra. Útil para cuando hay muchas categorías.}
-
-\item{\code{desplazar_porcentajes}}{Valor real. Parámetro \link{nudge_y} de la función \link{geom_text}. Aplica
+      \item{\code{desplazar_porcentajes}}{Valor real. Parámetro \link{nudge_y} de la función \link[ggplot2:geom_text]{geom_text}. Aplica
 sólo si \code{porcentajes_fuera} es \code{TRUE}.}
+      \item{\code{text_size}}{Valor tipo entero. Corresponde al tamaño de los porcentajes contenidos en la gráfica de barras.}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{text_size}}{Valor tipo entero. Corresponde al tamaño de los porcentajes contenidos en la gráfica de barras.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Descriptiva-gauge_numerica"></a>}}
 \if{latex}{\out{\hypertarget{method-Descriptiva-gauge_numerica}{}}}
-\subsection{Method \code{gauge_numerica()}}{
-Calcula las estimaciones de una única variable que representa una pregunta
+\subsection{\code{Descriptiva$gauge_numerica()}}{
+  Calcula las estimaciones de una única variable que representa una pregunta
 cuyas respuestas son únicamente del tipo numérica.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Descriptiva$gauge_numerica(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Descriptiva$gauge_numerica(
   codigo,
   color = "#850D2D",
   escala = c(0, 10),
   size_text_pct = 14
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{codigo}}{Valor tipo caracter. Nombre de la variable que se va a analizar.}
-
-\item{\code{color}}{Valor tipo caracter. Color en formato \code{HEX}. Es ekl color con el que se 'rellena'
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{codigo}}{Valor tipo caracter. Nombre de la variable que se va a analizar.}
+      \item{\code{color}}{Valor tipo caracter. Color en formato \code{HEX}. Es ekl color con el que se 'rellena'
 el gráfico tipo gauge.}
-
-\item{\code{escala}}{Dupla tipo numérica. Son los posibles valores mínimos y máximos posibles asociados
+      \item{\code{escala}}{Dupla tipo numérica. Son los posibles valores mínimos y máximos posibles asociados
 a la pregunta que representa la variable.}
+      \item{\code{size_text_pct}}{Valor entero. Determina el tamano del dentro dento del gráfico. Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{size_text_pct}}{Valor entero. Determina el tamano del dentro dento del gráfico. Es el parámetro
-\link{size} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Descriptiva-gauge_categorica"></a>}}
 \if{latex}{\out{\hypertarget{method-Descriptiva-gauge_categorica}{}}}
-\subsection{Method \code{gauge_categorica()}}{
-Calcula las estimaciones de un valor único de una única variable y lo muestra en
+\subsection{\code{Descriptiva$gauge_categorica()}}{
+  Calcula las estimaciones de un valor único de una única variable y lo muestra en
 una gráfica tipo gauge.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Descriptiva$gauge_categorica(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Descriptiva$gauge_categorica(
   codigo,
   filtro,
   color = "#850D2D",
   escala = c(0, 1),
   size_text_pct = 14
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{codigo}}{Valor tipo caracter. Nombre de la variable que se va a analizar.}
-
-\item{\code{filtro}}{Valor tipo caracter. Operación de identidad que se aplica como filtro entre los
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{codigo}}{Valor tipo caracter. Nombre de la variable que se va a analizar.}
+      \item{\code{filtro}}{Valor tipo caracter. Operación de identidad que se aplica como filtro entre los
 resultados de la variable de interés. Por ejemplo filtro = "respuesta == 'azul'".}
-
-\item{\code{color}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color con el que se 'rellena'
+      \item{\code{color}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color con el que se 'rellena'
 el gráfico tipo gauge.}
+      \item{\code{escala}}{Dupla tipo numérica. Por lo general, la escala es porcentual.}
+      \item{\code{size_text_pct}}{Valor entero. Determina el tamano del dentro dento del gráfico. Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{escala}}{Dupla tipo numérica. Por lo general, la escala es porcentual.}
-
-\item{\code{size_text_pct}}{Valor entero. Determina el tamano del dentro dento del gráfico. Es el parámetro
-\link{size} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Descriptiva-intervalo_numerica"></a>}}
 \if{latex}{\out{\hypertarget{method-Descriptiva-intervalo_numerica}{}}}
-\subsection{Method \code{intervalo_numerica()}}{
-Calcula las estimaciones de varias variables cuyos nombres inician con el mismo
+\subsection{\code{Descriptiva$intervalo_numerica()}}{
+  Calcula las estimaciones de varias variables cuyos nombres inician con el mismo
 patrón de caractere, cuyas respuestas son del tipo numérico y lo muestra en una gráfica única
-usando un \link[ggplot2:geom_linerange]{ggplot2::geom_pointrange} para cada variable. Por ejemplo calificacion_nombre1,
+usando un \link[ggplot2:geom_pointrange]{ggplot2::geom_pointrange} para cada variable. Por ejemplo calificacion_nombre1,
 calificacion_nombre2, calificacion_nombre3
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Descriptiva$intervalo_numerica(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Descriptiva$intervalo_numerica(
   patron,
   aspectos,
   escala = c(0, 10),
   point_size = 1,
   text_point_size = 8
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{patron}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{patron}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
 los nombres de las variables. De acuerdo al método sería "calificacion"}
-
-\item{\code{aspectos}}{Vector tipo caracter que identifica a las diferentes variables a procesar. De
+      \item{\code{aspectos}}{Vector tipo caracter que identifica a las diferentes variables a procesar. De
 acuerdo al ejemplo del método sería c("nombre1", "nombre2", "nombre3").}
-
-\item{\code{escala}}{Dupla tipo numérica. Son los posibles valores mínimos y máximos posibles asociados
+      \item{\code{escala}}{Dupla tipo numérica. Son los posibles valores mínimos y máximos posibles asociados
 a la pregunta que representa la variable.}
+      \item{\code{point_size}}{valor tipo entero. Determina el tamano del punto en la visuaización. Es
+el parámetro \link[ggplot2:size]{size} de la funcion \code{\link[ggplot2:geom_pointrange]{ggplot2::geom_pointrange()}}}
+      \item{\code{text_point_size}}{valor tipo entero. Determina el tamano del texto mostrado arriba del
+punto. Es el parámetro \link[ggplot2:size]{size} de la funcion \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{point_size}}{valor tipo entero. Determina el tamano del punto en la visuaización. Es
-el parámetro \link{size} de la funcion \code{\link[ggplot2:geom_linerange]{ggplot2::geom_pointrange()}}}
-
-\item{\code{text_point_size}}{valor tipo entero. Determina el tamano del texto mostrado arriba del
-punto. Es el parámetro \link{size} de la funcion \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Descriptiva-lollipops_categorica"></a>}}
 \if{latex}{\out{\hypertarget{method-Descriptiva-lollipops_categorica}{}}}
-\subsection{Method \code{lollipops_categorica()}}{
-Calcula las estimaciones de una variable y muestra los resultados en una
+\subsection{\code{Descriptiva$lollipops_categorica()}}{
+  Calcula las estimaciones de una variable y muestra los resultados en una
 gráfica tipo lollipops ordenadas de mayor a menor de forma vertical de acuerdo a las esitmaciones.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Descriptiva$lollipops_categorica(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Descriptiva$lollipops_categorica(
   codigo,
   orden = NULL,
   limits = c(0, 1),
@@ -322,92 +307,86 @@ gráfica tipo lollipops ordenadas de mayor a menor de forma vertical de acuerdo 
   size = 3,
   size_pct = 6,
   pct_otros = 0.01
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{codigo}}{Valor tipo caracter. Nombre de la variable que se va a analizar.}
-
-\item{\code{orden}}{Vector tipo caracter que contiene, de manera ordenada, los valores únicos de
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{codigo}}{Valor tipo caracter. Nombre de la variable que se va a analizar.}
+      \item{\code{orden}}{Vector tipo caracter que contiene, de manera ordenada, los valores únicos de
 la variable de interés y reordena las barras de la gráfica de barras de acuerdo a ese orden.}
-
-\item{\code{limits}}{Dupla tipo numérica. Delimita el límite inferior y superior del gráfico. Es el
-parámetro \link{limits} de la función \code{\link[ggplot2:scale_continuous]{ggplot2::scale_y_continuous()}}.}
-
-\item{\code{width_cats}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
-Aplica la función \code{\link[=str_wrap]{str_wrap()}} de la paquetería \link{stringr} a las labels del eje x.}
-
-\item{\code{size}}{Valor tipo entero. define el grueso de la linea del gráfico tipo lollipop. Es el
+      \item{\code{limits}}{Dupla tipo numérica. Delimita el límite inferior y superior del gráfico. Es el
+parámetro \link[ggplot2:limits]{limits} de la función \code{\link[ggplot2:scale_y_continuous]{ggplot2::scale_y_continuous()}}.}
+      \item{\code{width_cats}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
+Aplica la función \code{\link[stringr:str_wrap]{str_wrap()}} de la paquetería \link[stringr:stringr]{stringr} a las labels del eje x.}
+      \item{\code{size}}{Valor tipo entero. define el grueso de la linea del gráfico tipo lollipop. Es el
 argumento \link{linewidth} de la función \code{\link[ggplot2:geom_segment]{ggplot2::geom_segment()}}}
-
-\item{\code{size_pct}}{Valor entero. Determina el tamano del dentro dento del gráfico. Es el parámetro
-\link{size} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
-
-\item{\code{pct_otros}}{Valor real definido entre 0 y 1. A las categorias cuyas estimaciones sean menor
+      \item{\code{size_pct}}{Valor entero. Determina el tamano del dentro dento del gráfico. Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
+      \item{\code{pct_otros}}{Valor real definido entre 0 y 1. A las categorias cuyas estimaciones sean menor
 o igual que \code{pct_otros} las agrupa, las suma y las muestra en \code{Otros}.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Descriptiva-lollipops_multirespuesta"></a>}}
 \if{latex}{\out{\hypertarget{method-Descriptiva-lollipops_multirespuesta}{}}}
-\subsection{Method \code{lollipops_multirespuesta()}}{
-Calcula las estimaciones de varias variables cuyos nombres inician con el mismo
+\subsection{\code{Descriptiva$lollipops_multirespuesta()}}{
+  Calcula las estimaciones de varias variables cuyos nombres inician con el mismo
 patrón de caracteres. Dichas variables representan un conjunto de preguntar multirespuesta.
 Muestra los resultados en un gráfico tipo lollipops.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Descriptiva$lollipops_multirespuesta(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Descriptiva$lollipops_multirespuesta(
   patron_inicial,
   orden = NULL,
   limits = c(0, 1),
   width_cats = 15,
   size = 3,
   size_pct = 6
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{patron_inicial}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{patron_inicial}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
 los nombres de las variables.}
-
-\item{\code{orden}}{Vector tipo caracter que contiene, de manera ordenada, los valores únicos
+      \item{\code{orden}}{Vector tipo caracter que contiene, de manera ordenada, los valores únicos
 de la variable de interés y reordena las barras de la gráfica de barras de acuerdo a ese orden.}
-
-\item{\code{limits}}{Dupla tipo numérica. Son los posibles valores mínimos y máximos posibles asociados
+      \item{\code{limits}}{Dupla tipo numérica. Son los posibles valores mínimos y máximos posibles asociados
 a la pregunta que representa la variable.}
-
-\item{\code{width_cats}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
-Aplica la función \code{\link[=str_wrap]{str_wrap()}} de la paquetería \link{stringr} a las labels del eje x.}
-
-\item{\code{size}}{Valor tipo entero. define el grueso de la linea del gráfico tipo lollipop. Es el
+      \item{\code{width_cats}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.
+Aplica la función \code{\link[stringr:str_wrap]{str_wrap()}} de la paquetería \link[stringr:stringr]{stringr} a las labels del eje x.}
+      \item{\code{size}}{Valor tipo entero. define el grueso de la linea del gráfico tipo lollipop. Es el
 argumento \link{linewidth} de la función \code{\link[ggplot2:geom_segment]{ggplot2::geom_segment()}}}
+      \item{\code{size_pct}}{Valor entero. Determina el tamano del dentro dento del gráfico. Es el parámetro
+\link[ggplot2:size]{size} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{size_pct}}{Valor entero. Determina el tamano del dentro dento del gráfico. Es el parámetro
-\link{size} de la función \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}}.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Descriptiva-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Descriptiva-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Descriptiva$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Descriptiva$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Descriptiva$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Encuesta.Rd
+++ b/man/Encuesta.Rd
@@ -10,93 +10,94 @@ relacionada al levantamiento, respuestas y equipo que trabaja en campo. La clase
 cinco clases subordinadas: \code{Cuestionario}, \code{Respuestas}, \code{Muestra}, \code{Resultados} y \code{Auditoria}.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{muestra}}{El campo \code{muestra} contiene los resultados de ejecutar la clase \code{Muestra} de
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{muestra}}{El campo \code{muestra} contiene los resultados de ejecutar la clase \code{Muestra} de
 jerarquía menor. Dicha clase contiene el diseño muestral calculado a partir de la edad, sexo y
 geolocalización de los individuos entrevistados. Además del diseño muestral contiene métodos para
 modificar dicho diseño a partir de postestratificaciones o filtrar a través de subconjuntos de
 la muestra.}
 
-\item{\code{shp}}{El campo \code{shp} contiene la cartografía de los clusters que hayan sido seleccionados en
+    \item{\code{shp}}{El campo \code{shp} contiene la cartografía de los clusters que hayan sido seleccionados en
 el proceso de muestreo.}
 
-\item{\code{cuestionario}}{El campo \code{cuestionario} contiene los resultados de ejecutar la clase
+    \item{\code{cuestionario}}{El campo \code{cuestionario} contiene los resultados de ejecutar la clase
 \code{Cuestionario}. Dicha clase originalmente recibía el texto y las clases asociadas al cuestinoario
-en formato .docx y generaba el diccionario. Actualmente la clase recibe y asigna el \code{\link[=tibble]{tibble()}}
+en formato .docx y generaba el diccionario. Actualmente la clase recibe y asigna el \code{\link[tibble:tibble]{tibble()}}
 que contiene el diccionario y realiza unas cuantas verificaciones.}
 
-\item{\code{respuestas}}{El campo \code{respuestas} contiene los resultados de ejecutar la clase \code{Respuestas}
+    \item{\code{respuestas}}{El campo \code{respuestas} contiene los resultados de ejecutar la clase \code{Respuestas}
 de jerarquía menor. Dicha clase tiene como objetivo verificar, limpiar y estandarizar las
 respuestas recibidas de campo.}
 
-\item{\code{n_simulaciones}}{Valor entero usado para simular un \code{\link[=tibble]{tibble()}} necesario para generar
+    \item{\code{n_simulaciones}}{Valor entero usado para simular un \code{\link[tibble:tibble]{tibble()}} necesario para generar
 la clase \code{Respuestas}.}
 
-\item{\code{opinometro_id}}{Valor entero usado para generar el \code{\link[=tibble]{tibble()}} de respuestas a través
+    \item{\code{opinometro_id}}{Valor entero usado para generar el \code{\link[tibble:tibble]{tibble()}} de respuestas a través
 de la plataforma Opinómetro y que es necesario para generar la clase \code{Respuestas}.}
 
-\item{\code{pool}}{El campo \code{pool} se hereda para ser usado por la clase \code{Opinómetro}.}
+    \item{\code{pool}}{El campo \code{pool} se hereda para ser usado por la clase \code{Opinómetro}.}
 
-\item{\code{bd_categorias}}{El \code{\link[=tibble]{tibble()}} que contiene las categoriías generadas por IA se une al
-\code{\link[=tibble]{tibble()}} \code{respuestas} independientemente si el segundo es del campo \code{respuestas} o
+    \item{\code{bd_categorias}}{El \code{\link[tibble:tibble]{tibble()}} que contiene las categoriías generadas por IA se une al
+\code{\link[tibble:tibble]{tibble()}} \code{respuestas} independientemente si el segundo es del campo \code{respuestas} o
 generado por opinómetro.}
 
-\item{\code{bd_correcciones}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{bd_correcciones}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{patron}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{patron}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{auditoria_telefonica}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{auditoria_telefonica}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{quitar_vars}}{\code{DEPRECATED} en futuro desuso.}
+    \item{\code{quitar_vars}}{\code{DEPRECATED} en futuro desuso.}
 
-\item{\code{mantener}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{mantener}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{auditar}}{El campo se queda guardado en la clase \code{Encuesta} para su uso en la aplicación
+    \item{\code{auditar}}{El campo se queda guardado en la clase \code{Encuesta} para su uso en la aplicación
 de monitoreo del levantamiento.}
 
-\item{\code{vars_tendencias}}{El campo se queda guardado en la clase \code{Encuesta} para su uso en la
+    \item{\code{vars_tendencias}}{El campo se queda guardado en la clase \code{Encuesta} para su uso en la
 aplicación de monitoreo del levantamiento.}
 
-\item{\code{sin_peso}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{sin_peso}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{rake}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{rake}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{mantener_falta_coordenadas}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{mantener_falta_coordenadas}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{tipo_encuesta}}{Por defecto se imputa que el tipo de encuesta sea \code{ine}.}
+    \item{\code{tipo_encuesta}}{Por defecto se imputa que el tipo de encuesta sea \code{ine}.}
 
-\item{\code{shp_completo}}{Extensión del campo \code{shp}. Una vez calculadas las entrevistas efectivas y
+    \item{\code{shp_completo}}{Extensión del campo \code{shp}. Una vez calculadas las entrevistas efectivas y
 asignadas las ponderaciones. Se determinan las ubicaciones puntuales donde se levantaron las
 entrevistas y se agrega al objeto \code{shp}.}
 
-\item{\code{Resultados}}{Clase subordinada. La clase \code{Resultados} contiene todos los método utilizados
+    \item{\code{Resultados}}{Clase subordinada. La clase \code{Resultados} contiene todos los método utilizados
 para generar el entregable final.}
 
-\item{\code{Auditoria}}{Clase subordinada. La clase \code{Auditoria} en su mayor parte escribe el script de
+    \item{\code{Auditoria}}{Clase subordinada. La clase \code{Auditoria} en su mayor parte escribe el script de
 la aplicación de monitorio de en un \code{folder} llamado \code{auditoria} en el \verb{working directory}.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Encuesta-new}{\code{Encuesta$new()}}
-\item \href{#method-Encuesta-simular_surveytogo}{\code{Encuesta$simular_surveytogo()}}
-\item \href{#method-Encuesta-error_muestral_maximo}{\code{Encuesta$error_muestral_maximo()}}
-\item \href{#method-Encuesta-exportar_entregable}{\code{Encuesta$exportar_entregable()}}
-\item \href{#method-Encuesta-clone}{\code{Encuesta$clone()}}
-}
+  \itemize{
+    \item \href{#method-Encuesta-initialize}{\code{Encuesta$new()}}
+    \item \href{#method-Encuesta-simular_surveytogo}{\code{Encuesta$simular_surveytogo()}}
+    \item \href{#method-Encuesta-error_muestral_maximo}{\code{Encuesta$error_muestral_maximo()}}
+    \item \href{#method-Encuesta-exportar_entregable}{\code{Encuesta$exportar_entregable()}}
+    \item \href{#method-Encuesta-clone}{\code{Encuesta$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Encuesta-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Encuesta-new}{}}}
-\subsection{Method \code{new()}}{
-Se reciben los insumos de respuestas, auditoria y otros parámetros asociados
+\if{html}{\out{<a id="method-Encuesta-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Encuesta-initialize}{}}}
+\subsection{\code{Encuesta$new()}}{
+  Se reciben los insumos de respuestas, auditoria y otros parámetros asociados
 al levantamiento de la encuesta para construir el diseño muestral y las clases posteriores
 para generar resultados.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Encuesta$new(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Encuesta$new(
   muestra = NA,
   shp = NA,
   cuestionario = NA,
@@ -116,163 +117,149 @@ para generar resultados.
   rake = TRUE,
   mantener_falta_coordenadas = FALSE,
   tipo_encuesta = "ine"
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{muestra}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Es el diseño muestral
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{muestra}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Es el diseño muestral
 de la encuesta. El dobjeto \code{muestra} es de formato personalizado por lo que no es posible
 (o práctico) sustituirlo.}
-
-\item{\code{shp}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Contiene toda la
+      \item{\code{shp}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Contiene toda la
 cartografía utilizada para el equipo de campo y que a su vez es utilizada por la aplicación
 de monitoreo del levantamiento. El objeto \code{shp} es de formato personalizado por lo que no
 es posible (o práctico) sustituirlo.}
-
-\item{\code{cuestionario}}{\code{\link[=tibble]{tibble()}} que es el diccionario del cuestionario que se aplica a los
+      \item{\code{cuestionario}}{\code{\link[tibble:tibble]{tibble()}} que es el diccionario del cuestionario que se aplica a los
 entrevistados. El parámetro \code{cuestionario}, después de una actualización, actúa como el
 diccionario (o codebbok).}
-
-\item{\code{respuestas}}{\code{\link[=tibble]{tibble()}} de respuestas obtenidas por las personas entrevistadas.}
-
-\item{\code{n_simulaciones}}{Valor entero. Con el objetivo de publicar la aplicación de monitoreio
+      \item{\code{respuestas}}{\code{\link[tibble:tibble]{tibble()}} de respuestas obtenidas por las personas entrevistadas.}
+      \item{\code{n_simulaciones}}{Valor entero. Con el objetivo de publicar la aplicación de monitoreio
 antes de inciar el levantamiento es posible simular una base de respuestas.
 \code{n_simulaciones} es el total de respuestas simuladas, es decir, es el \code{\link[=nrow]{nrow()}} que simula
 al campo \code{respuestas}. El valor recomendado es del 10\% del total de entrevistas objetivo
 de la encuesta. Es mutuamente excluyente con el campo \code{respuestas}.}
-
-\item{\code{opinometro_id}}{Valor entero. Identificador del cuestionario aplicado en campo generado
+      \item{\code{opinometro_id}}{Valor entero. Identificador del cuestionario aplicado en campo generado
 en la plataforma \code{Opinómetro}. Es necesario consultar a la persona que construyó el
 cuestionario para conocer el \code{opinometro_id} asociado. Es mutuamente excluyente con el
 campo \code{respuestas}.}
-
-\item{\code{pool}}{Objeto tipo \link{pool} generado al conectarse a la base de datos que almacena las
-respuestas. Se recomienda utilizar la función \code{\link[=dbPool]{dbPool()}} de la paquetería \link{pool} para esto.}
-
-\item{\code{bd_categorias}}{\code{\link[=tibble]{tibble()}} que contiene los resultados generados por IA a partir de las
+      \item{\code{pool}}{Objeto tipo \link[pool:pool]{pool} generado al conectarse a la base de datos que almacena las
+respuestas. Se recomienda utilizar la función \code{\link[pool:dbPool]{dbPool()}} de la paquetería \link[pool:pool]{pool} para esto.}
+      \item{\code{bd_categorias}}{\code{\link[tibble:tibble]{tibble()}} que contiene los resultados generados por IA a partir de las
 preguntas abiertas.}
-
-\item{\code{bd_correcciones}}{\code{\link[=tibble]{tibble()}} que contiene las correcciones de los registros de las encuestas
+      \item{\code{bd_correcciones}}{\code{\link[tibble:tibble]{tibble()}} que contiene las correcciones de los registros de las encuestas
 efectivas.}
-
-\item{\code{patron}}{Valor tipo caracter que indica qué cadenas de texto quitar de las posibles opciones
+      \item{\code{patron}}{Valor tipo caracter que indica qué cadenas de texto quitar de las posibles opciones
 de respuesta a las preguntas para no presentarlas en los resultados.}
-
-\item{\code{auditoria_telefonica}}{\code{\link[=tibble]{tibble()}} que contiene las entrevistas que, por auditoría telefónica,
+      \item{\code{auditoria_telefonica}}{\code{\link[tibble:tibble]{tibble()}} que contiene las entrevistas que, por auditoría telefónica,
 han sido eliminadas de los registros.}
-
-\item{\code{quitar_vars}}{\code{DEPRECATED} Vector tipo caracter que contiene las variables que se desean
+      \item{\code{quitar_vars}}{\code{DEPRECATED} Vector tipo caracter que contiene las variables que se desean
 omitir del procesamiento.}
-
-\item{\code{mantener}}{Vector tipo caracter que indica los clusters a los cuales habrá que forzar las
+      \item{\code{mantener}}{Vector tipo caracter que indica los clusters a los cuales habrá que forzar las
 entrevistas que se hayan levantado cerca de los mismos.}
-
-\item{\code{auditar}}{Vector tipo caracter que contiene las varaibles que se mostraán en la aplicación
+      \item{\code{auditar}}{Vector tipo caracter que contiene las varaibles que se mostraán en la aplicación
 de monitoreo de levantamiento en la pestala \code{Resultados}.}
-
-\item{\code{vars_tendencias}}{Vector tipo caracter que contiene las variables que se mostrarán en la
+      \item{\code{vars_tendencias}}{Vector tipo caracter que contiene las variables que se mostrarán en la
 aplicación de monitoreo de levantamiento en la sección \code{Tendencias}.}
-
-\item{\code{sin_peso}}{\code{LOGICAL} Determina si esl diseno muestral construido será ponderado o no.}
-
-\item{\code{rake}}{\code{LOGICAL} Determina si el diseno muestral será postestratificado por edad y sexo.}
-
-\item{\code{mantener_falta_coordenadas}}{\code{LOGICAL}. Determina si se descartan o no las entrevistas sin
+      \item{\code{sin_peso}}{\code{LOGICAL} Determina si esl diseno muestral construido será ponderado o no.}
+      \item{\code{rake}}{\code{LOGICAL} Determina si el diseno muestral será postestratificado por edad y sexo.}
+      \item{\code{mantener_falta_coordenadas}}{\code{LOGICAL}. Determina si se descartan o no las entrevistas sin
 geolocalización válida o nula.}
-
-\item{\code{tipo_encuesta}}{\code{DEPRECATED}. La paquetería cuenta con un modo de cálculo de diseño muestral
+      \item{\code{tipo_encuesta}}{\code{DEPRECATED}. La paquetería cuenta con un modo de cálculo de diseño muestral
 análogo al \code{INEGI}. Sin embargo, este modo ha entrado en desuso y en un futuro desaparecerá.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Encuesta-simular_surveytogo"></a>}}
 \if{latex}{\out{\hypertarget{method-Encuesta-simular_surveytogo}{}}}
-\subsection{Method \code{simular_surveytogo()}}{
-Simula una base de respuestas de campo a parti del diccionario delos insumos mínumos necesarios
+\subsection{\code{Encuesta$simular_surveytogo()}}{
+  Simula una base de respuestas de campo a parti del diccionario delos insumos mínumos necesarios
 y suficientes.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Encuesta$simular_surveytogo(cuestionario, n, diseño, shp)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Encuesta$simular_surveytogo(cuestionario, n, diseño, shp)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{cuestionario}}{Campo de la clase encuesta.}
+      \item{\code{n}}{Valor entero. Define el \code{\link[=nrow]{nrow()}} del \code{\link[tibble:tibble]{tibble()}} de respuestas simuladas.}
+      \item{\code{diseño}}{Parámetro inicial de la clase \code{Encuesta}.}
+      \item{\code{shp}}{Parámetro inicial de la clase \code{Encuesta}.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{cuestionario}}{Campo de la clase encuesta.}
-
-\item{\code{n}}{Valor entero. Define el \code{\link[=nrow]{nrow()}} del \code{\link[=tibble]{tibble()}} de respuestas simuladas.}
-
-\item{\code{diseño}}{Parámetro inicial de la clase \code{Encuesta}.}
-
-\item{\code{shp}}{Parámetro inicial de la clase \code{Encuesta}.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Encuesta-error_muestral_maximo"></a>}}
 \if{latex}{\out{\hypertarget{method-Encuesta-error_muestral_maximo}{}}}
-\subsection{Method \code{error_muestral_maximo()}}{
-Cálculo del error muestral de cada pregunta de opción múltiple y despliegue de resultados
+\subsection{\code{Encuesta$error_muestral_maximo()}}{
+  Cálculo del error muestral de cada pregunta de opción múltiple y despliegue de resultados
 en forma de objeto de ggplot2
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Encuesta$error_muestral_maximo(quitar_patron = NULL)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Encuesta$error_muestral_maximo(quitar_patron = NULL)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{quitar_patron}}{Vector tipo vacater que contiene los patrones coumnes entre nombres
+de variables que se deben omitir en el cálculo.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{quitar_patron}}{Vector tipo vacater que contiene los patrones coumnes entre nombres
-de variables que se deben omitir en el cálculo.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Encuesta-exportar_entregable"></a>}}
 \if{latex}{\out{\hypertarget{method-Encuesta-exportar_entregable}{}}}
-\subsection{Method \code{exportar_entregable()}}{
-Exportar entregables al terminar cada levantamiento.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Encuesta$exportar_entregable(
+\subsection{\code{Encuesta$exportar_entregable()}}{
+  Exportar entregables al terminar cada levantamiento.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Encuesta$exportar_entregable(
   carpeta = "entregables",
   agregar = NULL,
   quitar = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{carpeta}}{Nombre de la carpeta de destino}
-
-\item{\code{agregar}}{Vector tipo caracter que contiene las variables que se entregan en la base
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{carpeta}}{Nombre de la carpeta de destino}
+      \item{\code{agregar}}{Vector tipo caracter que contiene las variables que se entregan en la base
 de datos.}
-
-\item{\code{quitar}}{Vector tipo caracter que contiene las variables que se omiten en la base
+      \item{\code{quitar}}{Vector tipo caracter que contiene las variables que se omiten en la base
 de datos.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Encuesta-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Encuesta-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Encuesta$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Encuesta$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Encuesta$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Especial.Rd
+++ b/man/Especial.Rd
@@ -9,79 +9,78 @@ cuya naturaleza inherente de la pregunta requiera de una adaptación particular 
 para visualizar los resultados.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{encuesta}}{Clase de jerarquía superior. Se requiere para extraer el diseno de la encuesta.}
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{encuesta}}{Clase de jerarquía superior. Se requiere para extraer el diseno de la encuesta.}
 
-\item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey} relacionado con el diseno de la
+    \item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey} relacionado con el diseno de la
 encuesta.}
 
-\item{\code{diccionario}}{Diccionario de procesamiento de la encuesta.}
+    \item{\code{diccionario}}{Diccionario de procesamiento de la encuesta.}
 
-\item{\code{tema}}{Objeto tipo \link{theme} de la paquetería \link{ggplot2}}
+    \item{\code{tema}}{Objeto tipo \link[ggplot2:theme]{theme} de la paquetería \link[ggplot2:ggplot2]{ggplot2}}
 
-\item{\code{graficadas}}{Campo heredado por la clase \code{Resultados}.}
-}
-\if{html}{\out{</div>}}
+    \item{\code{graficadas}}{Campo heredado por la clase \code{Resultados}.}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Especial-new}{\code{Especial$new()}}
-\item \href{#method-Especial-candidatoOpinion}{\code{Especial$candidatoOpinion()}}
-\item \href{#method-Especial-candidatoOpinion2}{\code{Especial$candidatoOpinion2()}}
-\item \href{#method-Especial-candidatoPartido}{\code{Especial$candidatoPartido()}}
-\item \href{#method-Especial-candidatoSaldo}{\code{Especial$candidatoSaldo()}}
-\item \href{#method-Especial-metodo_morena}{\code{Especial$metodo_morena()}}
-\item \href{#method-Especial-clone}{\code{Especial$clone()}}
-}
+  \itemize{
+    \item \href{#method-Especial-initialize}{\code{Especial$new()}}
+    \item \href{#method-Especial-candidatoOpinion}{\code{Especial$candidatoOpinion()}}
+    \item \href{#method-Especial-candidatoOpinion2}{\code{Especial$candidatoOpinion2()}}
+    \item \href{#method-Especial-candidatoPartido}{\code{Especial$candidatoPartido()}}
+    \item \href{#method-Especial-candidatoSaldo}{\code{Especial$candidatoSaldo()}}
+    \item \href{#method-Especial-metodo_morena}{\code{Especial$metodo_morena()}}
+    \item \href{#method-Especial-clone}{\code{Especial$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Especial-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Especial-new}{}}}
-\subsection{Method \code{new()}}{
-Define los insumos necesarios para preparar los métodos que producen los resultados
+\if{html}{\out{<a id="method-Especial-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Especial-initialize}{}}}
+\subsection{\code{Especial$new()}}{
+  Define los insumos necesarios para preparar los métodos que producen los resultados
 que requieren un tipo de visualización particular o compuesta.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Especial$new(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Especial$new(
   encuesta = NULL,
   diseno = NULL,
   diccionario = NULL,
   tema,
   graficadas = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{encuesta}}{Clase de jerarquía superior. Es el formato de la paquetería \code{encuestar}. Contiene
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{encuesta}}{Clase de jerarquía superior. Es el formato de la paquetería \code{encuestar}. Contiene
 el diseno muestral de la encuesta.}
-
-\item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey}. No se espera que los parametros
+      \item{\code{diseno}}{Objeto tipo \link{design} de la paquetería \link{survey}. No se espera que los parametros
 \code{encuesta} y \code{diseno} sean no nullos. El segundo sobreescribe el primero.}
-
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-
-\item{\code{tema}}{Objeto tipo \link{theme} de la paquetería \link{ggplot2}.}
-
-\item{\code{graficadas}}{Parametro heredado de la clase \code{Resultados}.}
+      \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+      \item{\code{tema}}{Objeto tipo \link[ggplot2:theme]{theme} de la paquetería \link[ggplot2:ggplot2]{ggplot2}.}
+      \item{\code{graficadas}}{Parametro heredado de la clase \code{Resultados}.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Especial-candidatoOpinion"></a>}}
 \if{latex}{\out{\hypertarget{method-Especial-candidatoOpinion}{}}}
-\subsection{Method \code{candidatoOpinion()}}{
-Visualiza los resultados de preguntas con mismas posibles respuestas y aplicadas
+\subsection{\code{Especial$candidatoOpinion()}}{
+  Visualiza los resultados de preguntas con mismas posibles respuestas y aplicadas
 sobre diferentes tópicos. Usualmente este tipo de preguntas son asociadas a la opinión y/o
 el conocimiento de personajes. El conjunto de preguntas están identificas, por ejemplo, como
 conocimiento_persona1, conocimiento_persona2, etc y opinion_persona1, opinion_persona2, etc.
 Por lo general, las variables de opinion destán condicionadas por las de conocimiento. Esto
 está considerado en el procesamiento de los resultados.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Especial$candidatoOpinion(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Especial$candidatoOpinion(
   patron_inicial,
   aspectos,
   ns_nc = "Ns/Nc",
@@ -109,109 +108,89 @@ está considerado en el procesamiento de los resultados.
   salto_respuestas = 100,
   mostrar_nsnc = T,
   orden_cat = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{patron_inicial}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{patron_inicial}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
 los nombres de las variables que representan la opinion. En el ejemplo este parámetro seía
 "opinion".}
-
-\item{\code{aspectos}}{Vector tipo caracter que identifica a las diferentes variables a procesar. De
+      \item{\code{aspectos}}{Vector tipo caracter que identifica a las diferentes variables a procesar. De
 acuerdo al método, el ejemplo sería c("persona1", "persona2").}
-
-\item{\code{ns_nc}}{Valor tipo caracter. Es el valor asociado a la respuesta  'No sabe o no contesta'
+      \item{\code{ns_nc}}{Valor tipo caracter. Es el valor asociado a la respuesta  'No sabe o no contesta'
 en la pregunta de opinión. Ya que este valor no aporta información, se separa de los resultados.}
-
-\item{\code{regular}}{Valor tipo caracter. Es el valor asociado a la respuesta  'Regular' que
+      \item{\code{regular}}{Valor tipo caracter. Es el valor asociado a la respuesta  'Regular' que
 representa una opinión neutra.}
-
-\item{\code{llave_burbuja}}{Valor tipo caracter. Si es no vacío, se visualizan las estimaciones
+      \item{\code{llave_burbuja}}{Valor tipo caracter. Si es no vacío, se visualizan las estimaciones
 relacionadas a la pregunta de conocimiento del personaje.}
-
-\item{\code{filtro_burbuja}}{Valor tipo caracter. Operación de identidad que se aplica como filtro
+      \item{\code{filtro_burbuja}}{Valor tipo caracter. Operación de identidad que se aplica como filtro
 entre los resultados de las preguntas asociadas al conocimiento. Por lo general el filtro
 tiene la forma filtro = "respuesta == 'Sí'". Este parámetro no afecta al cálculo de las
 estimaciones de las variables asociadas a la opinion, unicamente a las asociadas al conocimiento.}
-
-\item{\code{size_burbuja}}{Valor tipo entero. Determina el tamano de las "burbujas" que se usan para
+      \item{\code{size_burbuja}}{Valor tipo entero. Determina el tamano de las "burbujas" que se usan para
 visualizar los resultados de las preguntas asociadas al conocimiento. Es el parámetro \link{max_size}
-de la función \code{\link[ggplot2:scale_size]{ggplot2::scale_size_area()}}.}
-
-\item{\code{grupo_positivo}}{Vector tipo caracter. Indica los valores únicos de las variables asociadas
+de la función \code{\link[ggplot2:scale_size_area]{ggplot2::scale_size_area()}}.}
+      \item{\code{grupo_positivo}}{Vector tipo caracter. Indica los valores únicos de las variables asociadas
 a la pregunta de opinión que se consideran como 'opinion positiva" con el objetivo de ordenarlas
 de acuerdo a un gradiente de opinión}
-
-\item{\code{grupo_negativo}}{Vector tipo caracter. Indica los valores únicos de las variables asociadas
+      \item{\code{grupo_negativo}}{Vector tipo caracter. Indica los valores únicos de las variables asociadas
 a la pregunta de opinión que se consideran como 'opinion negativa" con el objetivo de ordenarlas
 de acuerdo a un gradiente de opinión}
-
-\item{\code{orden_resp}}{Vector tipo caracter que contiene los valores posibles de las respuestas
+      \item{\code{orden_resp}}{Vector tipo caracter que contiene los valores posibles de las respuestas
 de preguntas asociadas a la opinión.}
-
-\item{\code{colores_opinion}}{Vector tipo caracter. Color en formato \code{HEX}. Es el color con el que
+      \item{\code{colores_opinion}}{Vector tipo caracter. Color en formato \code{HEX}. Es el color con el que
 se 'rellena'cada proporción de opinión.}
-
-\item{\code{color_nsnc}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color con el que
+      \item{\code{color_nsnc}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color con el que
 se 'rellena' la proporción asociada a la respuesta 'No sabe o no contesta".}
-
-\item{\code{color_burbuja}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color con el que
+      \item{\code{color_burbuja}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color con el que
 se 'rellena' el gráfico relacionado a los resultados de la pregunta de conocimiento.}
-
-\item{\code{caption_burbuja}}{Valor tipo entero. Determina el tamano del texto mostrado en el
+      \item{\code{caption_burbuja}}{Valor tipo entero. Determina el tamano del texto mostrado en el
 \link{caption} de la visualizacion relacionada al conocimiento de la persona. Es el
-parámetro \link{size} de la función \code{\link[ggplot2:element]{ggplot2::element_text()}} aplicada al argumento
+parámetro \link[ggplot2:size]{size} de la función \code{\link[ggplot2:element_text]{ggplot2::element_text()}} aplicada al argumento
 \link{plot.caption} del \code{\link[ggplot2:theme]{ggplot2::theme()}}.}
-
-\item{\code{size_caption_opinion}}{Valor tipo entero. Determina el tamano del texto mostrado en el
-\link{caption} de la visualizacion principal. Es el parámetro \link{size} de la función
-\code{\link[ggplot2:element]{ggplot2::element_text()}} aplicada al argumento \link{plot.caption} del \code{\link[ggplot2:theme]{ggplot2::theme()}}.}
-
-\item{\code{size_caption_nsnc}}{Valor tipo entero. Determina el tamano del texto mostrado en el
+      \item{\code{size_caption_opinion}}{Valor tipo entero. Determina el tamano del texto mostrado en el
+\link{caption} de la visualizacion principal. Es el parámetro \link[ggplot2:size]{size} de la función
+\code{\link[ggplot2:element_text]{ggplot2::element_text()}} aplicada al argumento \link{plot.caption} del \code{\link[ggplot2:theme]{ggplot2::theme()}}.}
+      \item{\code{size_caption_nsnc}}{Valor tipo entero. Determina el tamano del texto mostrado en el
 \link{caption} de la visualizacion relacionada a la respuesta 'No sabe o no contesta". Es el
-parámetro \link{size} de la función \code{\link[ggplot2:element]{ggplot2::element_text()}} aplicada al argumento
+parámetro \link[ggplot2:size]{size} de la función \code{\link[ggplot2:element_text]{ggplot2::element_text()}} aplicada al argumento
 \link{plot.caption} del \code{\link[ggplot2:theme]{ggplot2::theme()}}.}
-
-\item{\code{size_text_cat}}{Valor tipo entero. Determina el tamano del texto mostrado en las
-etiquetas relacionadas a la opinión de personajes. Es el parámetro \link{size} de la función
-\code{\link[ggplot2:element]{ggplot2::element_text()}} aplicada al argumento \link{axis.text.y} del \code{\link[ggplot2:theme]{ggplot2::theme()}}.}
-
-\item{\code{size_pct}}{Valor tipo entero. Determina el tamano del texto mostrado dentro de las
-barras que representan las proporciones de opinion. Es el parámetro \link{size} de la función
+      \item{\code{size_text_cat}}{Valor tipo entero. Determina el tamano del texto mostrado en las
+etiquetas relacionadas a la opinión de personajes. Es el parámetro \link[ggplot2:size]{size} de la función
+\code{\link[ggplot2:element_text]{ggplot2::element_text()}} aplicada al argumento \link{axis.text.y} del \code{\link[ggplot2:theme]{ggplot2::theme()}}.}
+      \item{\code{size_pct}}{Valor tipo entero. Determina el tamano del texto mostrado dentro de las
+barras que representan las proporciones de opinion. Es el parámetro \link[ggplot2:size]{size} de la función
 \code{\link[ggfittext:geom_fit_text]{ggfittext::geom_fit_text()}}.}
-
-\item{\code{burbuja}}{\code{LOGICAL}. Determina si mostrar o no el gráfico relacionado a los resultados
+      \item{\code{burbuja}}{\code{LOGICAL}. Determina si mostrar o no el gráfico relacionado a los resultados
 de la pregunta de conocimiento.}
-
-\item{\code{salto}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.}
-
-\item{\code{salto_respuestas}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías
+      \item{\code{salto}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías en el eje x.}
+      \item{\code{salto_respuestas}}{Valor tipo entero. Reduce o aumenta la longitud de las categorías
 posibles de respuestas de las preguntas de opinion.}
-
-\item{\code{mostrar_nsnc}}{\code{LOGICAL}. Determina si mostrar o no los resultados de los valores
+      \item{\code{mostrar_nsnc}}{\code{LOGICAL}. Determina si mostrar o no los resultados de los valores
 "No sabe o no contesta".}
-
-\item{\code{orden_cat}}{Vector ordenado tipo caracter. Son los sufijos que las variables asociadas
+      \item{\code{orden_cat}}{Vector ordenado tipo caracter. Son los sufijos que las variables asociadas
 a las preguntas y ordena los resultados de acuerdo a dicho vector.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Especial-candidatoOpinion2"></a>}}
 \if{latex}{\out{\hypertarget{method-Especial-candidatoOpinion2}{}}}
-\subsection{Method \code{candidatoOpinion2()}}{
-Visualiza los resultados de preguntas con mismas posibles respuestas y aplicadas
+\subsection{\code{Especial$candidatoOpinion2()}}{
+  Visualiza los resultados de preguntas con mismas posibles respuestas y aplicadas
 sobre diferentes tópicos. Usualmente este tipo de preguntas son asociadas a la opinión y/o
 el conocimiento de personajes. El conjunto de preguntas están identificas, por ejemplo, como
 conocimiento_persona1, conocimiento_persona2, etc y opinion_persona1, opinion_persona2, etc.
 Por lo general, las variables de opinion destán condicionadas por las de conocimiento. Esto
 está considerado en el procesamiento de los resultados. La vsualizacion es en forma de
 tabla usando la paquetería \link{flextable}.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Especial$candidatoOpinion2(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Especial$candidatoOpinion2(
   patron_opinion,
   aspectos,
   ns_nc = "Ns/Nc",
@@ -228,69 +207,56 @@ tabla usando la paquetería \link{flextable}.
   size_text_body = 14,
   salto = 20,
   salto_respuestas = 100
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{patron_opinion}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{patron_opinion}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
 los nombres de las variables que representan la opinion. En el ejemplo este parámetro seía
 "opinion".}
-
-\item{\code{aspectos}}{Vector tipo caracter que identifica a las diferentes variables a procesar. De
+      \item{\code{aspectos}}{Vector tipo caracter que identifica a las diferentes variables a procesar. De
 acuerdo al método, el ejemplo sería c("persona1", "persona2").}
-
-\item{\code{ns_nc}}{Valor tipo caracter. Es el valor asociado a la respuesta  'No sabe o no contesta'
+      \item{\code{ns_nc}}{Valor tipo caracter. Es el valor asociado a la respuesta  'No sabe o no contesta'
 en la pregunta de opinión. Ya que este valor no aporta información, se separa de los resultados.}
-
-\item{\code{regular}}{Valor tipo caracter. Es el valor asociado a la respuesta  'Regular' que
+      \item{\code{regular}}{Valor tipo caracter. Es el valor asociado a la respuesta  'Regular' que
 representa una opinión neutra.}
-
-\item{\code{patron_conocimiento}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
+      \item{\code{patron_conocimiento}}{Valor tipo caracter. Es el patron inicial de caracteres que comparten
 los nombres de las variables que representan el conocimiento En el ejemplo este parámetro seía
 "opinion".}
-
-\item{\code{filtro_conocimiento}}{Valor tipo caracter. Operación de identidad que se aplica como filtro
+      \item{\code{filtro_conocimiento}}{Valor tipo caracter. Operación de identidad que se aplica como filtro
 entre los resultados de las preguntas asociadas al conocimiento. Por lo general el filtro
 tiene la forma filtro = "respuesta == 'Sí'". Este parámetro no afecta al cálculo de las
 estimaciones de las variables asociadas a la opinion, unicamente a las asociadas al conocimiento.}
-
-\item{\code{orden_opinion}}{Vector tipo caracter que contiene los valores posibles de las respuestas
+      \item{\code{orden_opinion}}{Vector tipo caracter que contiene los valores posibles de las respuestas
 de preguntas asociadas a la opinión. Las columnas de la tabla se orden de acuerdo a este vector}
-
-\item{\code{etiquetas}}{Dupla ordenada tipo caracter. Nombres de las variables para mostrar en el
+      \item{\code{etiquetas}}{Dupla ordenada tipo caracter. Nombres de las variables para mostrar en el
 resultado final.}
-
-\item{\code{colores_opinion}}{Vector tipo caracter. Color en formato \code{HEX}. Es el color con el que
+      \item{\code{colores_opinion}}{Vector tipo caracter. Color en formato \code{HEX}. Es el color con el que
 se 'rellena'cada proporción de opinión. Tantos colores como opiniones posibles.}
-
-\item{\code{colores_candidato}}{Vector que identifica los colores asociados a los valores únicos de la
+      \item{\code{colores_candidato}}{Vector que identifica los colores asociados a los valores únicos de la
 variable relacionada al candidato.}
-
-\item{\code{color_principal}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color con el que
+      \item{\code{color_principal}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color con el que
 se 'rellena'la parte principal de la tabla}
-
-\item{\code{color_conocimiento}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color con el que
+      \item{\code{color_conocimiento}}{Valor tipo caracter. Color en formato \code{HEX}. Es el color con el que
 se 'rellena'la columna de la tabla relacionada con los resultados de conocimiento.}
-
-\item{\code{size_text_header}}{Valor entero. Define el tamano del texto del encabezado}
-
-\item{\code{size_text_body}}{Valor entero. Define el tamano del texto del cuerpo de la tabla}
-
-\item{\code{salto}}{Valor entero. Define la longitud del texto de las filas}
-
-\item{\code{salto_respuestas}}{Valor entero. Define la longitu del texto de los encabezadps.}
+      \item{\code{size_text_header}}{Valor entero. Define el tamano del texto del encabezado}
+      \item{\code{size_text_body}}{Valor entero. Define el tamano del texto del cuerpo de la tabla}
+      \item{\code{salto}}{Valor entero. Define la longitud del texto de las filas}
+      \item{\code{salto_respuestas}}{Valor entero. Define la longitu del texto de los encabezadps.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Especial-candidatoPartido"></a>}}
 \if{latex}{\out{\hypertarget{method-Especial-candidatoPartido}{}}}
-\subsection{Method \code{candidatoPartido()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Especial$candidatoPartido(
+\subsection{\code{Especial$candidatoPartido()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Especial$candidatoPartido(
   llave_partido,
   llave_conocimiento,
   respuesta_conoce,
@@ -302,16 +268,18 @@ se 'rellena'la columna de la tabla relacionada con los resultados de conocimient
   corte_vis = 0,
   size_text = 6,
   size_text_conocimiento = 6
-)}\if{html}{\out{</div>}}
+)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Especial-candidatoSaldo"></a>}}
 \if{latex}{\out{\hypertarget{method-Especial-candidatoSaldo}{}}}
-\subsection{Method \code{candidatoSaldo()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Especial$candidatoSaldo(
+\subsection{\code{Especial$candidatoSaldo()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Especial$candidatoSaldo(
   llave_opinion,
   candidatos,
   positivos,
@@ -327,34 +295,39 @@ se 'rellena'la columna de la tabla relacionada con los resultados de conocimient
   size_text_legend = 10,
   size_pct = 12,
   size_caption_opinion = 10
-)}\if{html}{\out{</div>}}
+)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Especial-metodo_morena"></a>}}
 \if{latex}{\out{\hypertarget{method-Especial-metodo_morena}{}}}
-\subsection{Method \code{metodo_morena()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Especial$metodo_morena(personajes, atributos)}\if{html}{\out{</div>}}
+\subsection{\code{Especial$metodo_morena()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Especial$metodo_morena(personajes, atributos)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Especial-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Especial-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Especial$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Especial$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Especial$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Modelo.Rd
+++ b/man/Modelo.Rd
@@ -5,72 +5,78 @@
 \title{Esta es la clase de Modelo}
 \description{
 Esta es la clase de Modelo
-
-Esta es la clase de Modelo
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Modelo-new}{\code{Modelo$new()}}
-\item \href{#method-Modelo-correspondencia}{\code{Modelo$correspondencia()}}
-\item \href{#method-Modelo-componentesPrincipales}{\code{Modelo$componentesPrincipales()}}
-\item \href{#method-Modelo-clone}{\code{Modelo$clone()}}
-}
+  \itemize{
+    \item \href{#method-Modelo-initialize}{\code{Modelo$new()}}
+    \item \href{#method-Modelo-correspondencia}{\code{Modelo$correspondencia()}}
+    \item \href{#method-Modelo-componentesPrincipales}{\code{Modelo$componentesPrincipales()}}
+    \item \href{#method-Modelo-clone}{\code{Modelo$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Modelo-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Modelo-new}{}}}
-\subsection{Method \code{new()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Modelo$new(
+\if{html}{\out{<a id="method-Modelo-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Modelo-initialize}{}}}
+\subsection{\code{Modelo$new()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Modelo$new(
   encuesta = NULL,
   diseno = NULL,
   diccionario = NULL,
   tema,
   graficadas = NULL
-)}\if{html}{\out{</div>}}
+)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Modelo-correspondencia"></a>}}
 \if{latex}{\out{\hypertarget{method-Modelo-correspondencia}{}}}
-\subsection{Method \code{correspondencia()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Modelo$correspondencia(
+\subsection{\code{Modelo$correspondencia()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Modelo$correspondencia(
   var1,
   var2,
   legenda1 = NULL,
   legenda2 = NULL,
   colores = NULL
-)}\if{html}{\out{</div>}}
+)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Modelo-componentesPrincipales"></a>}}
 \if{latex}{\out{\hypertarget{method-Modelo-componentesPrincipales}{}}}
-\subsection{Method \code{componentesPrincipales()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Modelo$componentesPrincipales(variables)}\if{html}{\out{</div>}}
+\subsection{\code{Modelo$componentesPrincipales()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Modelo$componentesPrincipales(variables)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Modelo-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Modelo-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Modelo$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Modelo$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Modelo$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Muestra.Rd
+++ b/man/Muestra.Rd
@@ -114,7 +114,8 @@ alimentar el resto de la clase.
   tipo_encuesta,
   sin_peso,
   rake,
-  permitir_sin_conglomerados = FALSE
+  permitir_sin_conglomerados = FALSE,
+  umbral_rake = c(0.5, 2)
 )}
     \if{html}{\out{</div>}}
   }
@@ -136,6 +137,11 @@ entrevistas de una misma sección/manzana y subestima los errores
 estándar (~25\% medido en Chihuahua Ene-2026). Usa \code{TRUE} solo como
 decisión consciente del analista; se emite un warning y el diseño se
 construye estratificado sin conglomerados.}
+      \item{\code{umbral_rake}}{Vector \code{c(inferior, superior)} con el rango aceptable
+de los factores de ajuste del rake (default \code{c(0.5, 2)}). Sin cuotas en
+campo, el rake absorbe TODA la corrección de composición demográfica:
+factores fuera del umbral señalan un campo desbalanceado (revisar pases
+de horario) y disparan la varianza de las estimaciones.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/Muestra.Rd
+++ b/man/Muestra.Rd
@@ -12,276 +12,295 @@ diseno muestral de la clase para producir resultados con diferentes ponderacione
 La clase \code{Muestra} recibe.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{muestra}}{Campo de la clase \code{Encuesta}. Contiene toda la información necesaria para
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{muestra}}{Campo de la clase \code{Encuesta}. Contiene toda la información necesaria para
 calcular los pesos asignados a los individuos de acuerdo al proceso de muestreo.}
 
-\item{\code{base}}{\code{\link[=tibble]{tibble()}} que contiene la informacion de los factores de correccion poblacional
+    \item{\code{base}}{\code{\link[tibble:tibble]{tibble()}} que contiene la informacion de los factores de correccion poblacional
 de cada cluster}
 
-\item{\code{diseno_original}}{Diseno canonico u original de la encuesta}
+    \item{\code{diseno_original}}{Diseno canonico u original de la encuesta}
 
-\item{\code{region}}{Region (o estrato) del diseno actual de la encuesta. Es uno de los valores únicos
+    \item{\code{region}}{Region (o estrato) del diseno actual de la encuesta. Es uno de los valores únicos
 de la variable \code{region} creada durante el diseno muestral. Dicha variable actúa como estrato
 del marco muestral.}
 
-\item{\code{calibracion}}{Nombre de la calibración actualmente aplicada al diseno muestral.}
+    \item{\code{calibracion}}{Nombre de la calibración actualmente aplicada al diseno muestral.}
 
-\item{\code{diseno}}{Objeto tipo \code{design} de la paquetería \link{survey}}
+    \item{\code{diseno}}{Objeto tipo \code{design} de la paquetería \link{survey}}
 
-\item{\code{calibraciones}}{Lista de distintas calibraciones que se han agregado durante la produccion
+    \item{\code{calibraciones}}{Lista de distintas calibraciones que se han agregado durante la produccion
 a la clase.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Muestra-new}{\code{Muestra$new()}}
-\item \href{#method-Muestra-recalcular_fpc}{\code{Muestra$recalcular_fpc()}}
-\item \href{#method-Muestra-extraer_diseno}{\code{Muestra$extraer_diseno()}}
-\item \href{#method-Muestra-revisar_sexo}{\code{Muestra$revisar_sexo()}}
-\item \href{#method-Muestra-revisar_rango_edad}{\code{Muestra$revisar_rango_edad()}}
-\item \href{#method-Muestra-diseno_region}{\code{Muestra$diseno_region()}}
-\item \href{#method-Muestra-regresar_diseno_original}{\code{Muestra$regresar_diseno_original()}}
-\item \href{#method-Muestra-agregar_calibracion}{\code{Muestra$agregar_calibracion()}}
-\item \href{#method-Muestra-revisar_calibracion}{\code{Muestra$revisar_calibracion()}}
-\item \href{#method-Muestra-comparar_calibraciones}{\code{Muestra$comparar_calibraciones()}}
-\item \href{#method-Muestra-elegir_calibracion}{\code{Muestra$elegir_calibracion()}}
-\item \href{#method-Muestra-clone}{\code{Muestra$clone()}}
-}
+  \itemize{
+    \item \href{#method-Muestra-initialize}{\code{Muestra$new()}}
+    \item \href{#method-Muestra-recalcular_fpc}{\code{Muestra$recalcular_fpc()}}
+    \item \href{#method-Muestra-extraer_diseno}{\code{Muestra$extraer_diseno()}}
+    \item \href{#method-Muestra-revisar_sexo}{\code{Muestra$revisar_sexo()}}
+    \item \href{#method-Muestra-revisar_rango_edad}{\code{Muestra$revisar_rango_edad()}}
+    \item \href{#method-Muestra-diseno_region}{\code{Muestra$diseno_region()}}
+    \item \href{#method-Muestra-regresar_diseno_original}{\code{Muestra$regresar_diseno_original()}}
+    \item \href{#method-Muestra-agregar_calibracion}{\code{Muestra$agregar_calibracion()}}
+    \item \href{#method-Muestra-revisar_calibracion}{\code{Muestra$revisar_calibracion()}}
+    \item \href{#method-Muestra-comparar_calibraciones}{\code{Muestra$comparar_calibraciones()}}
+    \item \href{#method-Muestra-elegir_calibracion}{\code{Muestra$elegir_calibracion()}}
+    \item \href{#method-Muestra-clone}{\code{Muestra$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Muestra-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Muestra-new}{}}}
-\subsection{Method \code{new()}}{
-Se crean y calculan las variables y los pesos relacionados a los individuos
+\if{html}{\out{<a id="method-Muestra-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Muestra-initialize}{}}}
+\subsection{\code{Muestra$new()}}{
+  Se crean y calculan las variables y los pesos relacionados a los individuos
 entrevistados.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$new(muestra, respuestas, nivel, var_n)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{muestra}}{Campo heredado de la clase \code{Encuesta}.}
-
-\item{\code{respuestas}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas de los individuos entrevistados
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$new(muestra, respuestas, nivel, var_n)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{muestra}}{Campo heredado de la clase \code{Encuesta}.}
+      \item{\code{respuestas}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas de los individuos entrevistados
 en campo y que ha sido procesado por la clase \code{Respuestas}.}
-
-\item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro.}
-
-\item{\code{var_n}}{Valor tipo caracter que indica el nombre de la variable asociado al último
+      \item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro.}
+      \item{\code{var_n}}{Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Muestra-recalcular_fpc"></a>}}
 \if{latex}{\out{\hypertarget{method-Muestra-recalcular_fpc}{}}}
-\subsection{Method \code{recalcular_fpc()}}{
-Recalcula los factores de correccion poblacional de acuerdo a los individuos
+\subsection{\code{Muestra$recalcular_fpc()}}{
+  Recalcula los factores de correccion poblacional de acuerdo a los individuos
 entrevistados en campo
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$recalcular_fpc(respuestas, nivel, var_n)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{respuestas}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas de los individuos entrevistados}
-
-\item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro.}
-
-\item{\code{var_n}}{Valor tipo caracter que indica el nombre de la variable asociado al último
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$recalcular_fpc(respuestas, nivel, var_n)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{respuestas}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas de los individuos entrevistados}
+      \item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro.}
+      \item{\code{var_n}}{Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Muestra-extraer_diseno"></a>}}
 \if{latex}{\out{\hypertarget{method-Muestra-extraer_diseno}{}}}
-\subsection{Method \code{extraer_diseno()}}{
-Construye el objeto tipo \code{design} usado por la paquetería \link{survey} para
+\subsection{\code{Muestra$extraer_diseno()}}{
+  Construye el objeto tipo \code{design} usado por la paquetería \link{survey} para
 alimentar el resto de la clase.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$extraer_diseno(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$extraer_diseno(
   respuestas,
   marco_muestral,
   tipo_encuesta,
   sin_peso,
-  rake
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{respuestas}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas de los individuos entrevistados}
-
-\item{\code{marco_muestral}}{\code{\link[=tibble]{tibble()}} que contiene el marco muestral del proceso de muestreo}
-
-\item{\code{tipo_encuesta}}{Parametro heredado de la clase \code{Encuesta}. Define el tipo de diseno
+  rake,
+  permitir_sin_conglomerados = FALSE
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{respuestas}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas de los individuos entrevistados}
+      \item{\code{marco_muestral}}{\code{\link[tibble:tibble]{tibble()}} que contiene el marco muestral del proceso de muestreo}
+      \item{\code{tipo_encuesta}}{Parametro heredado de la clase \code{Encuesta}. Define el tipo de diseno
 muestral usado para calcular los pesos de los individuos}
-
-\item{\code{sin_peso}}{\code{LOGICAL}. Parámetro heredado de la clase encuesta. Si es \code{TRUE}, el diseno
+      \item{\code{sin_peso}}{\code{LOGICAL}. Parámetro heredado de la clase encuesta. Si es \code{TRUE}, el diseno
 se asume equiprobable.}
-
-\item{\code{rake}}{\code{LOGICAL} Parámetro heredado de la clase encuesta. Determina la postestratificacion
+      \item{\code{rake}}{\code{LOGICAL} Parámetro heredado de la clase encuesta. Determina la postestratificacion
 por edad y sexo.}
+      \item{\code{permitir_sin_conglomerados}}{\code{LOGICAL}. Si el diseño con conglomerados
+no puede construirse, el default (\code{FALSE}) detiene con un error informativo:
+un diseño sin conglomerados ignora la correlación intraclase de las
+entrevistas de una misma sección/manzana y subestima los errores
+estándar (~25\% medido en Chihuahua Ene-2026). Usa \code{TRUE} solo como
+decisión consciente del analista; se emite un warning y el diseño se
+construye estratificado sin conglomerados.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Muestra-revisar_sexo"></a>}}
 \if{latex}{\out{\hypertarget{method-Muestra-revisar_sexo}{}}}
-\subsection{Method \code{revisar_sexo()}}{
-Visualiza las proporciones de sexo entre los individuos entrevistados en
+\subsection{\code{Muestra$revisar_sexo()}}{
+  Visualiza las proporciones de sexo entre los individuos entrevistados en
 campo y lo que el diseno muestral indica que debe ser entrevistado.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$revisar_sexo()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$revisar_sexo()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Muestra-revisar_rango_edad"></a>}}
 \if{latex}{\out{\hypertarget{method-Muestra-revisar_rango_edad}{}}}
-\subsection{Method \code{revisar_rango_edad()}}{
-Visualiza las proporciones de rangos de edad entre los individuos entrevistados
+\subsection{\code{Muestra$revisar_rango_edad()}}{
+  Visualiza las proporciones de rangos de edad entre los individuos entrevistados
 en campo y lo que el diseno muestral indica que debe ser entrevistado.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$revisar_rango_edad()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$revisar_rango_edad()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Muestra-diseno_region"></a>}}
 \if{latex}{\out{\hypertarget{method-Muestra-diseno_region}{}}}
-\subsection{Method \code{diseno_region()}}{
-El método hace uso de la función \code{\link[=subset]{subset()}} para tomar un subconjunto de los
+\subsection{\code{Muestra$diseno_region()}}{
+  El método hace uso de la función \code{\link[=subset]{subset()}} para tomar un subconjunto de los
 datos obtenidos y producir resultados a partir de ellos respetando los pesos.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$diseno_region(seleccion)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$diseno_region(seleccion)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{seleccion}}{Valor tipo caracter de la variable \code{región}.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{seleccion}}{Valor tipo caracter de la variable \code{región}.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Muestra-regresar_diseno_original"></a>}}
 \if{latex}{\out{\hypertarget{method-Muestra-regresar_diseno_original}{}}}
-\subsection{Method \code{regresar_diseno_original()}}{
-Reinicia la modificación del diseño muestral aplicado a la clase. Si el diseño
+\subsection{\code{Muestra$regresar_diseno_original()}}{
+  Reinicia la modificación del diseño muestral aplicado a la clase. Si el diseño
 muestral ha sido modificado ya sea por métodos de la clase \code{Muestra} o de alguna otra forma
 este método garantiza aplica el diseño como si la clase recién se hubiera ejecutado.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$regresar_diseno_original()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$regresar_diseno_original()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Muestra-agregar_calibracion"></a>}}
 \if{latex}{\out{\hypertarget{method-Muestra-agregar_calibracion}{}}}
-\subsection{Method \code{agregar_calibracion()}}{
-Define calibraciones para aplicarlas al diseño muestral. El método está basado
+\subsection{\code{Muestra$agregar_calibracion()}}{
+  Define calibraciones para aplicarlas al diseño muestral. El método está basado
 en \code{\link[survey:calibrate]{survey::calibrate()}}
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$agregar_calibracion(vars, poblacion, nombre)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$agregar_calibracion(vars, poblacion, nombre)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{vars}}{Vector que indica las variables usadas en la calibración}
+      \item{\code{poblacion}}{poblacion poblacion contenida en cada estrato de la calibracion}
+      \item{\code{nombre}}{Nombre asignado a la calibración. Sirve para identificar diferentes calibraciones}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{vars}}{Vector que indica las variables usadas en la calibración}
-
-\item{\code{poblacion}}{poblacion poblacion contenida en cada estrato de la calibracion}
-
-\item{\code{nombre}}{Nombre asignado a la calibración. Sirve para identificar diferentes calibraciones}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Muestra-revisar_calibracion"></a>}}
 \if{latex}{\out{\hypertarget{method-Muestra-revisar_calibracion}{}}}
-\subsection{Method \code{revisar_calibracion()}}{
-Calcula el total poblacional de una calibracion aplicada al diseño muestral.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$revisar_calibracion(nombre)}\if{html}{\out{</div>}}
+\subsection{\code{Muestra$revisar_calibracion()}}{
+  Calcula el total poblacional de una calibracion aplicada al diseño muestral.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$revisar_calibracion(nombre)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{nombre}}{Nombre asignado a la calibración. Sirve para identificar diferentes calibraciones}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{nombre}}{Nombre asignado a la calibración. Sirve para identificar diferentes calibraciones}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Muestra-comparar_calibraciones"></a>}}
 \if{latex}{\out{\hypertarget{method-Muestra-comparar_calibraciones}{}}}
-\subsection{Method \code{comparar_calibraciones()}}{
-Compara las estimaciones para un mismo valor de diferentes variables aplciando
+\subsection{\code{Muestra$comparar_calibraciones()}}{
+  Compara las estimaciones para un mismo valor de diferentes variables aplciando
 las calibraciones existentes al diseño muestral
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$comparar_calibraciones(variables, valor_variables, vartype)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{variables}}{Vector tipo caracter que contiene los nombres de las variables a evaluar}
-
-\item{\code{valor_variables}}{Valores únicos de cada variable de interés para ser estimados}
-
-\item{\code{vartype}}{Argumento \link{vartype} de la función \code{\link[srvyr:survey_mean]{srvyr::survey_mean()}} que define el tipo
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$comparar_calibraciones(variables, valor_variables, vartype)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{variables}}{Vector tipo caracter que contiene los nombres de las variables a evaluar}
+      \item{\code{valor_variables}}{Valores únicos de cada variable de interés para ser estimados}
+      \item{\code{vartype}}{Argumento \link{vartype} de la función \code{\link[srvyr:survey_mean]{srvyr::survey_mean()}} que define el tipo
 de calculo de la variación.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Muestra-elegir_calibracion"></a>}}
 \if{latex}{\out{\hypertarget{method-Muestra-elegir_calibracion}{}}}
-\subsection{Method \code{elegir_calibracion()}}{
-Aplica la calibración seleccionada al diseño muestra de la encuesta.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$elegir_calibracion(nombre)}\if{html}{\out{</div>}}
+\subsection{\code{Muestra$elegir_calibracion()}}{
+  Aplica la calibración seleccionada al diseño muestra de la encuesta.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$elegir_calibracion(nombre)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{nombre}}{Nombre de la calibración a aplicar.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{nombre}}{Nombre de la calibración a aplicar.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Muestra-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Muestra-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Muestra$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Muestra$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Muestra$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Opinometro.Rd
+++ b/man/Opinometro.Rd
@@ -10,111 +10,119 @@ importante relevancia pues brinda a la paquetería una fuente de datos e insumos
 históricamente se a usado que es \code{SurveyToGo}.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{id_cuestionarioOpinometro}}{Campo heredado de la clase \code{Encuesta}.}
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{id_cuestionarioOpinometro}}{Campo heredado de la clase \code{Encuesta}.}
 
-\item{\code{pool}}{Campo heredado de la clase \code{Encuesta}.}
+    \item{\code{pool}}{Campo heredado de la clase \code{Encuesta}.}
 
-\item{\code{variables_cuestionario}}{Nombres de las variables que, de acuerdo al diccionario, forman el
+    \item{\code{variables_cuestionario}}{Nombres de las variables que, de acuerdo al diccionario, forman el
 conjunto de preguntas de la encuesta}
 
-\item{\code{bd_respuestas_cuestionario}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas serán utilizadas para
+    \item{\code{bd_respuestas_cuestionario}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas serán utilizadas para
 construir el diseño muestral de la encuesta.}
 
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta. Heredado de la
+    \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta. Heredado de la
 clase \code{Encuesta} o se provee de forma externa.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Opinometro-new}{\code{Opinometro$new()}}
-\item \href{#method-Opinometro-definir_contenido}{\code{Opinometro$definir_contenido()}}
-\item \href{#method-Opinometro-construir_respuestas}{\code{Opinometro$construir_respuestas()}}
-\item \href{#method-Opinometro-verificar_variables}{\code{Opinometro$verificar_variables()}}
-\item \href{#method-Opinometro-clone}{\code{Opinometro$clone()}}
-}
+  \itemize{
+    \item \href{#method-Opinometro-initialize}{\code{Opinometro$new()}}
+    \item \href{#method-Opinometro-definir_contenido}{\code{Opinometro$definir_contenido()}}
+    \item \href{#method-Opinometro-construir_respuestas}{\code{Opinometro$construir_respuestas()}}
+    \item \href{#method-Opinometro-verificar_variables}{\code{Opinometro$verificar_variables()}}
+    \item \href{#method-Opinometro-clone}{\code{Opinometro$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Opinometro-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Opinometro-new}{}}}
-\subsection{Method \code{new()}}{
-Establece conexión con la base de datos donde está alojada la
+\if{html}{\out{<a id="method-Opinometro-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Opinometro-initialize}{}}}
+\subsection{\code{Opinometro$new()}}{
+  Establece conexión con la base de datos donde está alojada la
 implementación del \code{Opinómetro}.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Opinometro$new(id_cuestionarioOpinometro = NA, pool = NA, diccionario = NULL)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{id_cuestionarioOpinometro}}{Valor entero. Identificador del cuestionario
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Opinometro$new(id_cuestionarioOpinometro = NA, pool = NA, diccionario = NULL)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{id_cuestionarioOpinometro}}{Valor entero. Identificador del cuestionario
 aplicado en campo generado en la plataforma \code{Opinómetro}.}
-
-\item{\code{pool}}{Objeto tipo \link{pool} generado al conectarse a la base de datos que
-almacena las respuestas. Se recomienda utilizar la función \code{\link[=dbPool]{dbPool()}} de la
-paquetería \link{pool} para esto.}
-
-\item{\code{diccionario}}{\code{\link[=tibble]{tibble()}} Diccionario (o codebook) del cuestionario de la
+      \item{\code{pool}}{Objeto tipo \link[pool:pool]{pool} generado al conectarse a la base de datos que
+almacena las respuestas. Se recomienda utilizar la función \code{\link[pool:dbPool]{dbPool()}} de la
+paquetería \link[pool:pool]{pool} para esto.}
+      \item{\code{diccionario}}{\code{\link[tibble:tibble]{tibble()}} Diccionario (o codebook) del cuestionario de la
 encuesta. Aunque la clase \code{Opinometro} reproduce el diccionario a partir del
 cuestionario construido en la plataforma \code{Opinometro}, el parametro \code{diccionario}
 es aquel que históricamente se ha utilizado para produccion. Es decir, aquel que
 está usualmente guardado en un archivo de excel y/o que recibe la clase \code{Encuesta}
 en el campo \code{diccionario}.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Opinometro-definir_contenido"></a>}}
 \if{latex}{\out{\hypertarget{method-Opinometro-definir_contenido}{}}}
-\subsection{Method \code{definir_contenido()}}{
-Determina las variables que están contenidas en la plataforma
+\subsection{\code{Opinometro$definir_contenido()}}{
+  Determina las variables que están contenidas en la plataforma
 \code{Opinometro}a partir de los campos construidos en el cuestinoario.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Opinometro$definir_contenido()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Opinometro$definir_contenido()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Opinometro-construir_respuestas"></a>}}
 \if{latex}{\out{\hypertarget{method-Opinometro-construir_respuestas}{}}}
-\subsection{Method \code{construir_respuestas()}}{
-Construye el \code{\link[=tibble]{tibble()}} de respuestas contenidas en la base de datos
+\subsection{\code{Opinometro$construir_respuestas()}}{
+  Construye el \code{\link[tibble:tibble]{tibble()}} de respuestas contenidas en la base de datos
 que tiene implementada la plataforma ``Opinometro`.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Opinometro$construir_respuestas()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Opinometro$construir_respuestas()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Opinometro-verificar_variables"></a>}}
 \if{latex}{\out{\hypertarget{method-Opinometro-verificar_variables}{}}}
-\subsection{Method \code{verificar_variables()}}{
-Notifica al usuario si hay variables faltantes o sobrantes en el \link{tibble}
+\subsection{\code{Opinometro$verificar_variables()}}{
+  Notifica al usuario si hay variables faltantes o sobrantes en el \link[tibble:tibble]{tibble}
 que contiene las respuestas.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Opinometro$verificar_variables()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Opinometro$verificar_variables()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Opinometro-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Opinometro-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Opinometro$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Opinometro$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Opinometro$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Opinometro_proc.Rd
+++ b/man/Opinometro_proc.Rd
@@ -10,118 +10,125 @@ importante relevancia pues brinda a la paquetería una fuente de datos e insumos
 históricamente se a usado que es \code{SurveyToGo}.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{id_cuestionarioOpinometro}}{Campo heredado de la clase \code{Encuesta}.}
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{id_cuestionarioOpinometro}}{Campo heredado de la clase \code{Encuesta}.}
 
-\item{\code{pool}}{Campo heredado de la clase \code{Encuesta}.}
+    \item{\code{pool}}{Campo heredado de la clase \code{Encuesta}.}
 
-\item{\code{variables_cuestionario}}{Nombres de las variables que, de acuerdo al diccionario, forman el
+    \item{\code{variables_cuestionario}}{Nombres de las variables que, de acuerdo al diccionario, forman el
 conjunto de preguntas de la encuesta}
 
-\item{\code{bd_respuestas_cuestionario}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas serán utilizadas para
+    \item{\code{bd_respuestas_cuestionario}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas serán utilizadas para
 construir el diseño muestral de la encuesta.}
 
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta. Heredado de la
+    \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta. Heredado de la
 clase \code{Encuesta} o se provee de forma externa.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Opinometro_proc-new}{\code{Opinometro_proc$new()}}
-\item \href{#method-Opinometro_proc-definir_contenido}{\code{Opinometro_proc$definir_contenido()}}
-\item \href{#method-Opinometro_proc-construir_respuestas}{\code{Opinometro_proc$construir_respuestas()}}
-\item \href{#method-Opinometro_proc-verificar_variables}{\code{Opinometro_proc$verificar_variables()}}
-\item \href{#method-Opinometro_proc-clone}{\code{Opinometro_proc$clone()}}
-}
+  \itemize{
+    \item \href{#method-Opinometro_proc-initialize}{\code{Opinometro_proc$new()}}
+    \item \href{#method-Opinometro_proc-definir_contenido}{\code{Opinometro_proc$definir_contenido()}}
+    \item \href{#method-Opinometro_proc-construir_respuestas}{\code{Opinometro_proc$construir_respuestas()}}
+    \item \href{#method-Opinometro_proc-verificar_variables}{\code{Opinometro_proc$verificar_variables()}}
+    \item \href{#method-Opinometro_proc-clone}{\code{Opinometro_proc$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Opinometro_proc-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Opinometro_proc-new}{}}}
-\subsection{Method \code{new()}}{
-Establece conexión con la base de datos donde está alojada la
+\if{html}{\out{<a id="method-Opinometro_proc-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Opinometro_proc-initialize}{}}}
+\subsection{\code{Opinometro_proc$new()}}{
+  Establece conexión con la base de datos donde está alojada la
 implementación del \code{Opinómetro}.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Opinometro_proc$new(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Opinometro_proc$new(
   id_cuestionarioOpinometro = NA,
   pool = NA,
   diccionario = NULL,
   bd_respuestas = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{id_cuestionarioOpinometro}}{Valor entero. Identificador del cuestionario
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{id_cuestionarioOpinometro}}{Valor entero. Identificador del cuestionario
 aplicado en campo generado en la plataforma \code{Opinómetro}.}
-
-\item{\code{pool}}{Objeto tipo \link{pool} generado al conectarse a la base de datos que
-almacena las respuestas. Se recomienda utilizar la función \code{\link[=dbPool]{dbPool()}} de la
-paquetería \link{pool} para esto.}
-
-\item{\code{diccionario}}{\code{\link[=tibble]{tibble()}} Diccionario (o codebook) del cuestionario de la
+      \item{\code{pool}}{Objeto tipo \link[pool:pool]{pool} generado al conectarse a la base de datos que
+almacena las respuestas. Se recomienda utilizar la función \code{\link[pool:dbPool]{dbPool()}} de la
+paquetería \link[pool:pool]{pool} para esto.}
+      \item{\code{diccionario}}{\code{\link[tibble:tibble]{tibble()}} Diccionario (o codebook) del cuestionario de la
 encuesta. Aunque la clase \code{Opinometro} reproduce el diccionario a partir del
 cuestionario construido en la plataforma \code{Opinometro}, el parametro \code{diccionario}
 es aquel que históricamente se ha utilizado para produccion. Es decir, aquel que
 está usualmente guardado en un archivo de excel y/o que recibe la clase \code{Encuesta}
 en el campo \code{diccionario}.}
+      \item{\code{bd_respuestas}}{\code{\link[tibble:tibble]{tibble()}} Respuestas de la base del opinometro}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{bd_respuestas}}{\code{\link[=tibble]{tibble()}} Respuestas de la base del opinometro}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Opinometro_proc-definir_contenido"></a>}}
 \if{latex}{\out{\hypertarget{method-Opinometro_proc-definir_contenido}{}}}
-\subsection{Method \code{definir_contenido()}}{
-Determina las variables que están contenidas en la plataforma
+\subsection{\code{Opinometro_proc$definir_contenido()}}{
+  Determina las variables que están contenidas en la plataforma
 \code{Opinometro}a partir de los campos construidos en el cuestinoario.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Opinometro_proc$definir_contenido()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Opinometro_proc$definir_contenido()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Opinometro_proc-construir_respuestas"></a>}}
 \if{latex}{\out{\hypertarget{method-Opinometro_proc-construir_respuestas}{}}}
-\subsection{Method \code{construir_respuestas()}}{
-Construye el \code{\link[=tibble]{tibble()}} de respuestas contenidas en la base de datos
+\subsection{\code{Opinometro_proc$construir_respuestas()}}{
+  Construye el \code{\link[tibble:tibble]{tibble()}} de respuestas contenidas en la base de datos
 que tiene implementada la plataforma ``Opinometro`.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Opinometro_proc$construir_respuestas(bd_respuestas)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Opinometro_proc$construir_respuestas(bd_respuestas)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Opinometro_proc-verificar_variables"></a>}}
 \if{latex}{\out{\hypertarget{method-Opinometro_proc-verificar_variables}{}}}
-\subsection{Method \code{verificar_variables()}}{
-Notifica al usuario si hay variables faltantes o sobrantes en el \link{tibble}
+\subsection{\code{Opinometro_proc$verificar_variables()}}{
+  Notifica al usuario si hay variables faltantes o sobrantes en el \link[tibble:tibble]{tibble}
 que contiene las respuestas.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Opinometro_proc$verificar_variables()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Opinometro_proc$verificar_variables()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Opinometro_proc-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Opinometro_proc-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Opinometro_proc$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Opinometro_proc$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Opinometro_proc$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Preproceso.Rd
+++ b/man/Preproceso.Rd
@@ -10,113 +10,114 @@ relacionada al levantamiento, respuestas y equipo que trabaja en campo. La clase
 cinco clases subordinadas: \code{Cuestionario}, \code{Respuestas}, \code{Muestra}, \code{Resultados} y \code{Auditoria}.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{muestra}}{El campo \code{muestra} contiene los resultados de ejecutar la clase \code{Muestra} de
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{muestra}}{El campo \code{muestra} contiene los resultados de ejecutar la clase \code{Muestra} de
 jerarquía menor. Dicha clase contiene el diseño muestral calculado a partir de la edad, sexo y
 geolocalización de los individuos entrevistados. Además del diseño muestral contiene métodos para
 modificar dicho diseño a partir de postestratificaciones o filtrar a través de subconjuntos de
 la muestra.}
 
-\item{\code{shp}}{El campo \code{shp} contiene la cartografía de los clusters que hayan sido seleccionados en
+    \item{\code{shp}}{El campo \code{shp} contiene la cartografía de los clusters que hayan sido seleccionados en
 el proceso de muestreo.}
 
-\item{\code{cuestionario}}{El campo \code{cuestionario} contiene los resultados de ejecutar la clase
+    \item{\code{cuestionario}}{El campo \code{cuestionario} contiene los resultados de ejecutar la clase
 \code{Cuestionario}. Dicha clase originalmente recibía el texto y las clases asociadas al cuestinoario
-en formato .docx y generaba el diccionario. Actualmente la clase recibe y asigna el \code{\link[=tibble]{tibble()}}
+en formato .docx y generaba el diccionario. Actualmente la clase recibe y asigna el \code{\link[tibble:tibble]{tibble()}}
 que contiene el diccionario y realiza unas cuantas verificaciones.}
 
-\item{\code{respuestas}}{El campo \code{respuestas} contiene los resultados de ejecutar la clase \code{Respuestas}
+    \item{\code{respuestas}}{El campo \code{respuestas} contiene los resultados de ejecutar la clase \code{Respuestas}
 de jerarquía menor. Dicha clase tiene como objetivo verificar, limpiar y estandarizar las
 respuestas recibidas de campo.}
 
-\item{\code{n_simulaciones}}{Valor entero usado para simular un \code{\link[=tibble]{tibble()}} necesario para generar
+    \item{\code{n_simulaciones}}{Valor entero usado para simular un \code{\link[tibble:tibble]{tibble()}} necesario para generar
 la clase \code{Respuestas}.}
 
-\item{\code{opinometro_id}}{Valor entero usado para generar el \code{\link[=tibble]{tibble()}} de respuestas a través
+    \item{\code{opinometro_id}}{Valor entero usado para generar el \code{\link[tibble:tibble]{tibble()}} de respuestas a través
 de la plataforma Opinómetro y que es necesario para generar la clase \code{Respuestas}.}
 
-\item{\code{pool}}{El campo \code{pool} se hereda para ser usado por la clase \code{Opinómetro}.}
+    \item{\code{pool}}{El campo \code{pool} se hereda para ser usado por la clase \code{Opinómetro}.}
 
-\item{\code{bd_categorias}}{El \code{\link[=tibble]{tibble()}} que contiene las categoriías generadas por IA se une al
-\code{\link[=tibble]{tibble()}} \code{respuestas} independientemente si el segundo es del campo \code{respuestas} o
+    \item{\code{bd_categorias}}{El \code{\link[tibble:tibble]{tibble()}} que contiene las categoriías generadas por IA se une al
+\code{\link[tibble:tibble]{tibble()}} \code{respuestas} independientemente si el segundo es del campo \code{respuestas} o
 generado por opinómetro.}
 
-\item{\code{patron}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{patron}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{auditoria_telefonica}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{auditoria_telefonica}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{quitar_vars}}{\code{DEPRECATED} en futuro desuso.}
+    \item{\code{quitar_vars}}{\code{DEPRECATED} en futuro desuso.}
 
-\item{\code{mantener}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{mantener}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{mantener_falta_coordenadas}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{mantener_falta_coordenadas}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{tipo_encuesta}}{Por defecto se imputa que el tipo de encuesta sea \code{ine}.}
+    \item{\code{tipo_encuesta}}{Por defecto se imputa que el tipo de encuesta sea \code{ine}.}
 
-\item{\code{shp_completo}}{Extensión del campo \code{shp}. Una vez calculadas las entrevistas efectivas y
+    \item{\code{shp_completo}}{Extensión del campo \code{shp}. Una vez calculadas las entrevistas efectivas y
 asignadas las ponderaciones. Se determinan las ubicaciones puntuales donde se levantaron las
 entrevistas y se agrega al objeto \code{shp}.}
 
-\item{\code{Resultados}}{Clase subordinada. La clase \code{Resultados} contiene todos los método utilizados
+    \item{\code{Resultados}}{Clase subordinada. La clase \code{Resultados} contiene todos los método utilizados
 para generar el entregable final.}
 
-\item{\code{Auditoria}}{Clase subordinada. La clase \code{Auditoria} en su mayor parte escribe el script de
+    \item{\code{Auditoria}}{Clase subordinada. La clase \code{Auditoria} en su mayor parte escribe el script de
 la aplicación de monitorio de en un \code{folder} llamado \code{auditoria} en el \verb{working directory}.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Active bindings}{
-\if{html}{\out{<div class="r6-active-bindings">}}
-\describe{
-\item{\code{muestra}}{El campo \code{muestra} contiene los resultados de ejecutar la clase \code{Muestra} de
+  \if{html}{\out{<div class="r6-active-bindings">}}
+  \describe{
+    \item{\code{muestra}}{El campo \code{muestra} contiene los resultados de ejecutar la clase \code{Muestra} de
 jerarquía menor. Dicha clase contiene el diseño muestral calculado a partir de la edad, sexo y
 geolocalización de los individuos entrevistados. Además del diseño muestral contiene métodos para
 modificar dicho diseño a partir de postestratificaciones o filtrar a través de subconjuntos de
 la muestra.}
 
-\item{\code{respuestas}}{El campo \code{respuestas} contiene los resultados de ejecutar la clase \code{Respuestas}
+    \item{\code{respuestas}}{El campo \code{respuestas} contiene los resultados de ejecutar la clase \code{Respuestas}
 de jerarquía menor. Dicha clase tiene como objetivo verificar, limpiar y estandarizar las
 respuestas recibidas de campo.}
 
-\item{\code{n_simulaciones}}{Valor entero usado para simular un \code{\link[=tibble]{tibble()}} necesario para generar
+    \item{\code{n_simulaciones}}{Valor entero usado para simular un \code{\link[tibble:tibble]{tibble()}} necesario para generar
 la clase \code{Respuestas}.}
 
-\item{\code{quitar_vars}}{\code{DEPRECATED} en futuro desuso.}
+    \item{\code{quitar_vars}}{\code{DEPRECATED} en futuro desuso.}
 
-\item{\code{mantener_falta_coordenadas}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{mantener_falta_coordenadas}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{Resultados}}{Clase subordinada. La clase \code{Resultados} contiene todos los método utilizados
+    \item{\code{Resultados}}{Clase subordinada. La clase \code{Resultados} contiene todos los método utilizados
 para generar el entregable final.}
 
-\item{\code{Auditoria}}{Clase subordinada. La clase \code{Auditoria} en su mayor parte escribe el script de
+    \item{\code{Auditoria}}{Clase subordinada. La clase \code{Auditoria} en su mayor parte escribe el script de
 la aplicación de monitorio de en un \code{folder} llamado \code{auditoria} en el \verb{working directory}.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Preproceso-new}{\code{Preproceso$new()}}
-\item \href{#method-Preproceso-preparar_respuestas}{\code{Preproceso$preparar_respuestas()}}
-\item \href{#method-Preproceso-procesar_nuevas_entradas}{\code{Preproceso$procesar_nuevas_entradas()}}
-\item \href{#method-Preproceso-actualizar_bd}{\code{Preproceso$actualizar_bd()}}
-\item \href{#method-Preproceso-generar_diseno}{\code{Preproceso$generar_diseno()}}
-\item \href{#method-Preproceso-clone}{\code{Preproceso$clone()}}
-}
+  \itemize{
+    \item \href{#method-Preproceso-initialize}{\code{Preproceso$new()}}
+    \item \href{#method-Preproceso-preparar_respuestas}{\code{Preproceso$preparar_respuestas()}}
+    \item \href{#method-Preproceso-procesar_nuevas_entradas}{\code{Preproceso$procesar_nuevas_entradas()}}
+    \item \href{#method-Preproceso-actualizar_bd}{\code{Preproceso$actualizar_bd()}}
+    \item \href{#method-Preproceso-generar_diseno}{\code{Preproceso$generar_diseno()}}
+    \item \href{#method-Preproceso-clone}{\code{Preproceso$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Preproceso-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Preproceso-new}{}}}
-\subsection{Method \code{new()}}{
-Se reciben los insumos de respuestas, auditoria y otros parámetros asociados
+\if{html}{\out{<a id="method-Preproceso-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Preproceso-initialize}{}}}
+\subsection{\code{Preproceso$new()}}{
+  Se reciben los insumos de respuestas, auditoria y otros parámetros asociados
 al levantamiento de la encuesta para construir el diseño muestral y las clases posteriores
 para generar resultados.
 
 
-Asigna todos los insumos a la clase sin procesarlos.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Preproceso$new(
+  Asigna todos los insumos a la clase sin procesarlos.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Preproceso$new(
   pool = NULL,
   opinometro_id = NULL,
   bd_respuestas = NULL,
@@ -127,114 +128,116 @@ Asigna todos los insumos a la clase sin procesarlos.
   mantener = "",
   auditoria_telefonica = NULL,
   bd_eliminadas_regla = NULL,
+  bd_eliminadas_reglas = NULL,
   shp = NULL,
   tipo_encuesta = NULL,
   patron = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{pool}}{Objeto tipo \link{pool} generado al conectarse a la base de datos que almacena las
-respuestas. Se recomienda utilizar la función \code{\link[=dbPool]{dbPool()}} de la paquetería \link{pool} para esto.}
-
-\item{\code{opinometro_id}}{Valor entero. Identificador del cuestionario aplicado en campo generado
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{pool}}{Objeto tipo \link[pool:pool]{pool} generado al conectarse a la base de datos que almacena las
+respuestas. Se recomienda utilizar la función \code{\link[pool:dbPool]{dbPool()}} de la paquetería \link[pool:pool]{pool} para esto.}
+      \item{\code{opinometro_id}}{Valor entero. Identificador del cuestionario aplicado en campo generado
 en la plataforma \code{Opinómetro}. Es necesario consultar a la persona que construyó el
 cuestionario para conocer el \code{opinometro_id} asociado. Es mutuamente excluyente con el
 campo \code{respuestas}.}
-
-\item{\code{bd_categorias}}{\code{\link[=tibble]{tibble()}} que contiene los resultados generados por IA a partir de las
+      \item{\code{bd_categorias}}{\code{\link[tibble:tibble]{tibble()}} que contiene los resultados generados por IA a partir de las
 preguntas abiertas.}
-
-\item{\code{cuestionario}}{\code{\link[=tibble]{tibble()}} que es el diccionario del cuestionario que se aplica a los
+      \item{\code{cuestionario}}{\code{\link[tibble:tibble]{tibble()}} que es el diccionario del cuestionario que se aplica a los
 entrevistados. El parámetro \code{cuestionario}, después de una actualización, actúa como el
 diccionario (o codebbok).}
-
-\item{\code{muestra}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Es el diseño muestral
+      \item{\code{muestra}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Es el diseño muestral
 de la encuesta. El dobjeto \code{muestra} es de formato personalizado por lo que no es posible
 (o práctico) sustituirlo.}
-
-\item{\code{mantener}}{Vector tipo caracter que indica los clusters a los cuales habrá que forzar las
+      \item{\code{mantener}}{Vector tipo caracter que indica los clusters a los cuales habrá que forzar las
 entrevistas que se hayan levantado cerca de los mismos.}
-
-\item{\code{auditoria_telefonica}}{\code{\link[=tibble]{tibble()}} que contiene las entrevistas que, por auditoría telefónica,
+      \item{\code{auditoria_telefonica}}{\code{\link[tibble:tibble]{tibble()}} que contiene las entrevistas que, por auditoría telefónica,
 han sido eliminadas de los registros.}
-
-\item{\code{shp}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Contiene toda la
+      \item{\code{shp}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Contiene toda la
 cartografía utilizada para el equipo de campo y que a su vez es utilizada por la aplicación
 de monitoreo del levantamiento. El objeto \code{shp} es de formato personalizado por lo que no
 es posible (o práctico) sustituirlo.}
-
-\item{\code{patron}}{Valor tipo caracter que indica qué cadenas de texto quitar de las posibles opciones
+      \item{\code{tipo_encuesta}}{Por defecto se imputa que el tipo de encuesta sea \code{ine}.}
+      \item{\code{patron}}{Valor tipo caracter que indica qué cadenas de texto quitar de las posibles opciones
 de respuesta a las preguntas para no presentarlas en los resultados.}
-
-\item{\code{respuestas}}{\code{\link[=tibble]{tibble()}} de respuestas obtenidas por las personas entrevistadas.
+      \item{\code{respuestas}}{\code{\link[tibble:tibble]{tibble()}} de respuestas obtenidas por las personas entrevistadas.
 de la encuesta. Es mutuamente excluyente con el campo \code{respuestas}.}
-
-\item{\code{quitar_vars}}{\code{DEPRECATED} Vector tipo caracter que contiene las variables que se desean
+      \item{\code{quitar_vars}}{\code{DEPRECATED} Vector tipo caracter que contiene las variables que se desean
 omitir del procesamiento.}
-
-\item{\code{mantener_falta_coordenadas}}{\code{LOGICAL}. Determina si se descartan o no las entrevistas sin
+      \item{\code{mantener_falta_coordenadas}}{\code{LOGICAL}. Determina si se descartan o no las entrevistas sin
 geolocalización válida o nula.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Preproceso-preparar_respuestas"></a>}}
 \if{latex}{\out{\hypertarget{method-Preproceso-preparar_respuestas}{}}}
-\subsection{Method \code{preparar_respuestas()}}{
-Prepara la base de respuestas cruda (GPS y variables clave).
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Preproceso$preparar_respuestas()}\if{html}{\out{</div>}}
+\subsection{\code{Preproceso$preparar_respuestas()}}{
+  Prepara la base de respuestas cruda (GPS y variables clave).
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Preproceso$preparar_respuestas()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Preproceso-procesar_nuevas_entradas"></a>}}
 \if{latex}{\out{\hypertarget{method-Preproceso-procesar_nuevas_entradas}{}}}
-\subsection{Method \code{procesar_nuevas_entradas()}}{
-Procesa las nuevas respuestas: filtra, limpia y las prepara
+\subsection{\code{Preproceso$procesar_nuevas_entradas()}}{
+  Procesa las nuevas respuestas: filtra, limpia y las prepara
 para ser añadidas al snapshot.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Preproceso$procesar_nuevas_entradas()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Preproceso$procesar_nuevas_entradas()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Preproceso-actualizar_bd"></a>}}
 \if{latex}{\out{\hypertarget{method-Preproceso-actualizar_bd}{}}}
-\subsection{Method \code{actualizar_bd()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Preproceso$actualizar_bd()}\if{html}{\out{</div>}}
+\subsection{\code{Preproceso$actualizar_bd()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Preproceso$actualizar_bd()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Preproceso-generar_diseno"></a>}}
 \if{latex}{\out{\hypertarget{method-Preproceso-generar_diseno}{}}}
-\subsection{Method \code{generar_diseno()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Preproceso$generar_diseno()}\if{html}{\out{</div>}}
+\subsection{\code{Preproceso$generar_diseno()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Preproceso$generar_diseno()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Preproceso-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Preproceso-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Preproceso$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Preproceso$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Preproceso$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Regiones.Rd
+++ b/man/Regiones.Rd
@@ -5,71 +5,78 @@
 \title{Esta es la clase de Regiones}
 \description{
 Esta es la clase de Regiones
-
-Esta es la clase de Regiones
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Regiones-new}{\code{Regiones$new()}}
-\item \href{#method-Regiones-mapa_ganador}{\code{Regiones$mapa_ganador()}}
-\item \href{#method-Regiones-mapa_degradadoNumerico}{\code{Regiones$mapa_degradadoNumerico()}}
-\item \href{#method-Regiones-heatmap_conocimiento}{\code{Regiones$heatmap_conocimiento()}}
-\item \href{#method-Regiones-heatmap_saldoOpinion}{\code{Regiones$heatmap_saldoOpinion()}}
-\item \href{#method-Regiones-mapa_resaltarRegion}{\code{Regiones$mapa_resaltarRegion()}}
-\item \href{#method-Regiones-crear_shp_regiones}{\code{Regiones$crear_shp_regiones()}}
-\item \href{#method-Regiones-resaltar_region}{\code{Regiones$resaltar_region()}}
-\item \href{#method-Regiones-clone}{\code{Regiones$clone()}}
-}
+  \itemize{
+    \item \href{#method-Regiones-initialize}{\code{Regiones$new()}}
+    \item \href{#method-Regiones-mapa_ganador}{\code{Regiones$mapa_ganador()}}
+    \item \href{#method-Regiones-mapa_degradadoNumerico}{\code{Regiones$mapa_degradadoNumerico()}}
+    \item \href{#method-Regiones-heatmap_conocimiento}{\code{Regiones$heatmap_conocimiento()}}
+    \item \href{#method-Regiones-heatmap_saldoOpinion}{\code{Regiones$heatmap_saldoOpinion()}}
+    \item \href{#method-Regiones-mapa_resaltarRegion}{\code{Regiones$mapa_resaltarRegion()}}
+    \item \href{#method-Regiones-crear_shp_regiones}{\code{Regiones$crear_shp_regiones()}}
+    \item \href{#method-Regiones-resaltar_region}{\code{Regiones$resaltar_region()}}
+    \item \href{#method-Regiones-clone}{\code{Regiones$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Regiones-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Regiones-new}{}}}
-\subsection{Method \code{new()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Regiones$new(encuesta = NULL, diseno = NULL, diccionario = NULL, tema)}\if{html}{\out{</div>}}
+\if{html}{\out{<a id="method-Regiones-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Regiones-initialize}{}}}
+\subsection{\code{Regiones$new()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Regiones$new(encuesta = NULL, diseno = NULL, diccionario = NULL, tema)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Regiones-mapa_ganador"></a>}}
 \if{latex}{\out{\hypertarget{method-Regiones-mapa_ganador}{}}}
-\subsection{Method \code{mapa_ganador()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Regiones$mapa_ganador(variable, region = "region", lugar = 1, na_rm = T)}\if{html}{\out{</div>}}
+\subsection{\code{Regiones$mapa_ganador()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Regiones$mapa_ganador(variable, region = "region", lugar = 1, na_rm = T)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Regiones-mapa_degradadoNumerico"></a>}}
 \if{latex}{\out{\hypertarget{method-Regiones-mapa_degradadoNumerico}{}}}
-\subsection{Method \code{mapa_degradadoNumerico()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Regiones$mapa_degradadoNumerico(variable)}\if{html}{\out{</div>}}
+\subsection{\code{Regiones$mapa_degradadoNumerico()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Regiones$mapa_degradadoNumerico(variable)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Regiones-heatmap_conocimiento"></a>}}
 \if{latex}{\out{\hypertarget{method-Regiones-heatmap_conocimiento}{}}}
-\subsection{Method \code{heatmap_conocimiento()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Regiones$heatmap_conocimiento(
+\subsection{\code{Regiones$heatmap_conocimiento()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Regiones$heatmap_conocimiento(
   patron_llaveConocimiento,
   candidatos,
   respuesta,
   ordenRegiones = NULL,
   salto_labelRegiones = 5
-)}\if{html}{\out{</div>}}
+)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Regiones-heatmap_saldoOpinion"></a>}}
 \if{latex}{\out{\hypertarget{method-Regiones-heatmap_saldoOpinion}{}}}
-\subsection{Method \code{heatmap_saldoOpinion()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Regiones$heatmap_saldoOpinion(
+\subsection{\code{Regiones$heatmap_saldoOpinion()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Regiones$heatmap_saldoOpinion(
   patron_llaveOpinion,
   candidatos,
   ns_nc,
@@ -78,52 +85,61 @@ Esta es la clase de Regiones
   cat_positivo,
   ordenRegiones = NULL,
   salto_labelRegiones = 5
-)}\if{html}{\out{</div>}}
+)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Regiones-mapa_resaltarRegion"></a>}}
 \if{latex}{\out{\hypertarget{method-Regiones-mapa_resaltarRegion}{}}}
-\subsection{Method \code{mapa_resaltarRegion()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Regiones$mapa_resaltarRegion(region, color)}\if{html}{\out{</div>}}
+\subsection{\code{Regiones$mapa_resaltarRegion()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Regiones$mapa_resaltarRegion(region, color)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Regiones-crear_shp_regiones"></a>}}
 \if{latex}{\out{\hypertarget{method-Regiones-crear_shp_regiones}{}}}
-\subsection{Method \code{crear_shp_regiones()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Regiones$crear_shp_regiones()}\if{html}{\out{</div>}}
+\subsection{\code{Regiones$crear_shp_regiones()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Regiones$crear_shp_regiones()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Regiones-resaltar_region"></a>}}
 \if{latex}{\out{\hypertarget{method-Regiones-resaltar_region}{}}}
-\subsection{Method \code{resaltar_region()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Regiones$resaltar_region(color)}\if{html}{\out{</div>}}
+\subsection{\code{Regiones$resaltar_region()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Regiones$resaltar_region(color)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Regiones-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Regiones-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Regiones$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Regiones$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Regiones$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Respuestas.Rd
+++ b/man/Respuestas.Rd
@@ -8,74 +8,73 @@ La clase \code{Respuestas} tiene como objetivo coonsolidar, limpiar y preparar l
 respuestas de los individuos entrevistados en campo.
 }
 \section{Super class}{
-\code{\link[encuestar:Encuesta]{encuestar::Encuesta}} -> \code{Respuestas}
+\code{\link[encuestar:Encuesta]{Encuesta}} -> \code{Respuestas}
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{eliminadas}}{El campo \code{eliminadas} contiene el \code{\link[=tibble]{tibble()}} de entrevistas eliminadas por
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{eliminadas}}{El campo \code{eliminadas} contiene el \code{\link[tibble:tibble]{tibble()}} de entrevistas eliminadas por
 auditoría.}
 
-\item{\code{cluster_corregido}}{El campo \code{cluster_corregido} contiene el \code{\link[=tibble]{tibble()}} de entrevistas cuyo
+    \item{\code{cluster_corregido}}{El campo \code{cluster_corregido} contiene el \code{\link[tibble:tibble]{tibble()}} de entrevistas cuyo
 cluster haya sido corregido por geolocalización.}
 
-\item{\code{base}}{El campo \code{base} contiene el \code{\link[=tibble]{tibble()}} de las respuestas serán utilizadas para construir
+    \item{\code{base}}{El campo \code{base} contiene el \code{\link[tibble:tibble]{tibble()}} de las respuestas serán utilizadas para construir
 el diseño muestral de la encuesta.}
 
-\item{\code{catalogo}}{El campo \code{catálogo} contiene el catálogo de variables en el cual se definen aqueelas
+    \item{\code{catalogo}}{El campo \code{catálogo} contiene el catálogo de variables en el cual se definen aqueelas
 que son necesarias y suficientes para construir un diseño muestral.}
 
-\item{\code{n}}{El campo \code{n} está en desuso.}
+    \item{\code{n}}{El campo \code{n} está en desuso.}
 
-\item{\code{m}}{El campo \code{m} está en desuso.}
+    \item{\code{m}}{El campo \code{m} está en desuso.}
 
-\item{\code{sin_coordenadas}}{El campo \code{sin_coordenadas} contiene el \code{\link[=tibble]{tibble()}} de, en caso de existir,
+    \item{\code{sin_coordenadas}}{El campo \code{sin_coordenadas} contiene el \code{\link[tibble:tibble]{tibble()}} de, en caso de existir,
 entrevistas que no tienen una geolicalización válida.}
 
-\item{\code{mantener_falta_coordenadas}}{\code{LOGICAL} determina si las entrevistas que no tienen una
+    \item{\code{mantener_falta_coordenadas}}{\code{LOGICAL} determina si las entrevistas que no tienen una
 geolocalización válida se descartan o no.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Respuestas-new}{\code{Respuestas$new()}}
-\item \href{#method-Respuestas-nombres}{\code{Respuestas$nombres()}}
-\item \href{#method-Respuestas-q_patron}{\code{Respuestas$q_patron()}}
-\item \href{#method-Respuestas-categorias}{\code{Respuestas$categorias()}}
-\item \href{#method-Respuestas-respuestas_sin_seleccion}{\code{Respuestas$respuestas_sin_seleccion()}}
-\item \href{#method-Respuestas-eliminar_auditoria_telefonica}{\code{Respuestas$eliminar_auditoria_telefonica()}}
-\item \href{#method-Respuestas-corregir_respuestas}{\code{Respuestas$corregir_respuestas()}}
-\item \href{#method-Respuestas-crear_variablesSecundarias}{\code{Respuestas$crear_variablesSecundarias()}}
-\item \href{#method-Respuestas-coordenadas_faltantes}{\code{Respuestas$coordenadas_faltantes()}}
-\item \href{#method-Respuestas-eliminar_falta_coordenadas}{\code{Respuestas$eliminar_falta_coordenadas()}}
-\item \href{#method-Respuestas-correccion_cluster}{\code{Respuestas$correccion_cluster()}}
-\item \href{#method-Respuestas-eliminar_fuera_muestra}{\code{Respuestas$eliminar_fuera_muestra()}}
-\item \href{#method-Respuestas-calcular_distancia}{\code{Respuestas$calcular_distancia()}}
-\item \href{#method-Respuestas-eliminar_faltantes_diseno}{\code{Respuestas$eliminar_faltantes_diseno()}}
-\item \href{#method-Respuestas-vars_diseno}{\code{Respuestas$vars_diseno()}}
-\item \href{#method-Respuestas-retirar_no_efectivas}{\code{Respuestas$retirar_no_efectivas()}}
-\item \href{#method-Respuestas-clone}{\code{Respuestas$clone()}}
+  \itemize{
+    \item \href{#method-Respuestas-initialize}{\code{Respuestas$new()}}
+    \item \href{#method-Respuestas-nombres}{\code{Respuestas$nombres()}}
+    \item \href{#method-Respuestas-q_patron}{\code{Respuestas$q_patron()}}
+    \item \href{#method-Respuestas-categorias}{\code{Respuestas$categorias()}}
+    \item \href{#method-Respuestas-respuestas_sin_seleccion}{\code{Respuestas$respuestas_sin_seleccion()}}
+    \item \href{#method-Respuestas-eliminar_auditoria_telefonica}{\code{Respuestas$eliminar_auditoria_telefonica()}}
+    \item \href{#method-Respuestas-corregir_respuestas}{\code{Respuestas$corregir_respuestas()}}
+    \item \href{#method-Respuestas-crear_variablesSecundarias}{\code{Respuestas$crear_variablesSecundarias()}}
+    \item \href{#method-Respuestas-coordenadas_faltantes}{\code{Respuestas$coordenadas_faltantes()}}
+    \item \href{#method-Respuestas-eliminar_falta_coordenadas}{\code{Respuestas$eliminar_falta_coordenadas()}}
+    \item \href{#method-Respuestas-correccion_cluster}{\code{Respuestas$correccion_cluster()}}
+    \item \href{#method-Respuestas-eliminar_fuera_muestra}{\code{Respuestas$eliminar_fuera_muestra()}}
+    \item \href{#method-Respuestas-calcular_distancia}{\code{Respuestas$calcular_distancia()}}
+    \item \href{#method-Respuestas-eliminar_faltantes_diseno}{\code{Respuestas$eliminar_faltantes_diseno()}}
+    \item \href{#method-Respuestas-vars_diseno}{\code{Respuestas$vars_diseno()}}
+    \item \href{#method-Respuestas-retirar_no_efectivas}{\code{Respuestas$retirar_no_efectivas()}}
+    \item \href{#method-Respuestas-clone}{\code{Respuestas$clone()}}
+  }
 }
-}
-\if{html}{\out{
-<details open><summary>Inherited methods</summary>
+\if{html}{\out{<details open><summary>Inherited methods</summary>
 <ul>
-<li><span class="pkg-link" data-pkg="encuestar" data-topic="Encuesta" data-id="error_muestral_maximo"><a href='../../encuestar/html/Encuesta.html#method-Encuesta-error_muestral_maximo'><code>encuestar::Encuesta$error_muestral_maximo()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="encuestar" data-topic="Encuesta" data-id="exportar_entregable"><a href='../../encuestar/html/Encuesta.html#method-Encuesta-exportar_entregable'><code>encuestar::Encuesta$exportar_entregable()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="encuestar" data-topic="Encuesta" data-id="simular_surveytogo"><a href='../../encuestar/html/Encuesta.html#method-Encuesta-simular_surveytogo'><code>encuestar::Encuesta$simular_surveytogo()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="encuestar" data-topic="Encuesta" data-id="error_muestral_maximo"><a href='../../encuestar/html/Encuesta.html#method-Encuesta-error_muestral_maximo'><code>Encuesta$error_muestral_maximo()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="encuestar" data-topic="Encuesta" data-id="exportar_entregable"><a href='../../encuestar/html/Encuesta.html#method-Encuesta-exportar_entregable'><code>Encuesta$exportar_entregable()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="encuestar" data-topic="Encuesta" data-id="simular_surveytogo"><a href='../../encuestar/html/Encuesta.html#method-Encuesta-simular_surveytogo'><code>Encuesta$simular_surveytogo()</code></a></span></li>
 </ul>
-</details>
-}}
+</details>}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Respuestas-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Respuestas-new}{}}}
-\subsection{Method \code{new()}}{
-Se reciben los diferentes insumos relacionados a la encuesta para estandarizar
+\if{html}{\out{<a id="method-Respuestas-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Respuestas-initialize}{}}}
+\subsection{\code{Respuestas$new()}}{
+  Se reciben los diferentes insumos relacionados a la encuesta para estandarizar
 las respuestas que formarán parte del diseÑo muestral.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$new(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$new(
   base = NULL,
   catalogo = NA,
   encuesta = NULL,
@@ -84,343 +83,349 @@ las respuestas que formarán parte del diseÑo muestral.
   patron = NA,
   nivel = NULL,
   var_n = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{base}}{\code{\link[=tibble]{tibble()}} que contiene la base de datos de respuestas de las personas entrevistadas.}
-
-\item{\code{catalogo}}{\code{\link[=tibble]{tibble()}} que contiene el catalogo de variables.}
-
-\item{\code{encuesta}}{Clase de jerarquía mayor.}
-
-\item{\code{muestra_completa}}{Objeto de formato personalizado generado por la paquetería \code{muestrear}.
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{base}}{\code{\link[tibble:tibble]{tibble()}} que contiene la base de datos de respuestas de las personas entrevistadas.}
+      \item{\code{catalogo}}{\code{\link[tibble:tibble]{tibble()}} que contiene el catalogo de variables.}
+      \item{\code{encuesta}}{Clase de jerarquía mayor.}
+      \item{\code{muestra_completa}}{Objeto de formato personalizado generado por la paquetería \code{muestrear}.
 Contiene el diseño muestral completo de la encuesta.}
-
-\item{\code{mantener_falta_coordenadas}}{\code{LOGICAL} determina si las entrevistas que no tienen una
+      \item{\code{mantener_falta_coordenadas}}{\code{LOGICAL} determina si las entrevistas que no tienen una
 geolocalización válida se descartan o no.}
-
-\item{\code{patron}}{Cadena de caracteres que se removerán de todas las respuestas recibidas en
+      \item{\code{patron}}{Cadena de caracteres que se removerán de todas las respuestas recibidas en
 campo.}
-
-\item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro.}
-
-\item{\code{var_n}}{Valor tipo caracter que indica el nombre de la variable asociado al último
+      \item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro.}
+      \item{\code{var_n}}{Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-nombres"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-nombres}{}}}
-\subsection{Method \code{nombres()}}{
-Determina si la base de respuestas contiene todas las variables que, de acuerdo
+\subsection{\code{Respuestas$nombres()}}{
+  Determina si la base de respuestas contiene todas las variables que, de acuerdo
 al diccionario, deben ser procesadas.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$nombres(catalogo_variables, bd, diccionario)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$nombres(catalogo_variables, bd, diccionario)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{catalogo_variables}}{\code{\link[tibble:tibble]{tibble()}} que contiene el catálogo de variables.}
+      \item{\code{bd}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{catalogo_variables}}{\code{\link[=tibble]{tibble()}} que contiene el catálogo de variables.}
-
-\item{\code{bd}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-q_patron"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-q_patron}{}}}
-\subsection{Method \code{q_patron()}}{
-Quita cadenas de texto de las respuetas de campo heredadas del cuestionario
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$q_patron(bd, dicc, patron)}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas$q_patron()}}{
+  Quita cadenas de texto de las respuetas de campo heredadas del cuestionario
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$q_patron(bd, dicc, patron)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{bd}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{dicc}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+      \item{\code{patron}}{Cadena o cadenas de texto que se desean quitar de las respuestas de campo}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{bd}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{dicc}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-
-\item{\code{patron}}{Cadena o cadenas de texto que se desean quitar de las respuestas de campo}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-categorias"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-categorias}{}}}
-\subsection{Method \code{categorias()}}{
-Determina diferencias entre las respuestas recolectadas en campo y las esperadas
+\subsection{\code{Respuestas$categorias()}}{
+  Determina diferencias entre las respuestas recolectadas en campo y las esperadas
 de acuerdo al diccionario
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$categorias(bd, diccionario)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$categorias(bd, diccionario)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{bd}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{bd}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-respuestas_sin_seleccion"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-respuestas_sin_seleccion}{}}}
-\subsection{Method \code{respuestas_sin_seleccion()}}{
-Determina las respuestas esperadas que no han sido seleccionadas por los
+\subsection{\code{Respuestas$respuestas_sin_seleccion()}}{
+  Determina las respuestas esperadas que no han sido seleccionadas por los
 entrevistados
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$respuestas_sin_seleccion(bd, diccionario)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$respuestas_sin_seleccion(bd, diccionario)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{bd}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{bd}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-eliminar_auditoria_telefonica"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-eliminar_auditoria_telefonica}{}}}
-\subsection{Method \code{eliminar_auditoria_telefonica()}}{
-Descarta las entrevistas que, de acuerdo a la base de auditoria telefónica,
+\subsection{\code{Respuestas$eliminar_auditoria_telefonica()}}{
+  Descarta las entrevistas que, de acuerdo a la base de auditoria telefónica,
 deben ser descartadas.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$eliminar_auditoria_telefonica(auditoria_telefonica)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$eliminar_auditoria_telefonica(auditoria_telefonica)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{auditoria_telefonica}}{\code{\link[tibble:tibble]{tibble()}} que contiene las entrevistas que, de acuerdo a
+auditoría, se van a eliminar del registro.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{auditoria_telefonica}}{\code{\link[=tibble]{tibble()}} que contiene las entrevistas que, de acuerdo a
-auditoría, se van a eliminar del registro.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-corregir_respuestas"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-corregir_respuestas}{}}}
-\subsection{Method \code{corregir_respuestas()}}{
-Corrige las respuestas de los entrevistados de acuerdo a la base de correcciones
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$corregir_respuestas(respuestas, bd_correcciones_raw)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{respuestas}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{bd_correcciones_raw}}{\code{\link[=tibble]{tibble()}} que contiene la relación de entrevista, variable en la
+\subsection{\code{Respuestas$corregir_respuestas()}}{
+  Corrige las respuestas de los entrevistados de acuerdo a la base de correcciones
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$corregir_respuestas(respuestas, bd_correcciones_raw)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{respuestas}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{bd_correcciones_raw}}{\code{\link[tibble:tibble]{tibble()}} que contiene la relación de entrevista, variable en la
 cual está incorrecto el registro y valor correcto de la respuesta}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-crear_variablesSecundarias"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-crear_variablesSecundarias}{}}}
-\subsection{Method \code{crear_variablesSecundarias()}}{
-Crea variables que, por defecto, se usan en la producción y entrega de resultados
+\subsection{\code{Respuestas$crear_variablesSecundarias()}}{
+  Crea variables que, por defecto, se usan en la producción y entrega de resultados
 de Morant Consultores
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$crear_variablesSecundarias(diccionario)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$crear_variablesSecundarias(diccionario)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-coordenadas_faltantes"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-coordenadas_faltantes}{}}}
-\subsection{Method \code{coordenadas_faltantes()}}{
-Determina las entrevistas con variables de geolocalización no válidas
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$coordenadas_faltantes()}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas$coordenadas_faltantes()}}{
+  Determina las entrevistas con variables de geolocalización no válidas
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$coordenadas_faltantes()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-eliminar_falta_coordenadas"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-eliminar_falta_coordenadas}{}}}
-\subsection{Method \code{eliminar_falta_coordenadas()}}{
-Descarta y registra las entrevistas con variables de geolocalización no válidas
+\subsection{\code{Respuestas$eliminar_falta_coordenadas()}}{
+  Descarta y registra las entrevistas con variables de geolocalización no válidas
 y comunica al usuario esa operación
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$eliminar_falta_coordenadas()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$eliminar_falta_coordenadas()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-correccion_cluster"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-correccion_cluster}{}}}
-\subsection{Method \code{correccion_cluster()}}{
-Con base en la geolocalización de la entrevista, determina el cluster (o sección)
+\subsection{\code{Respuestas$correccion_cluster()}}{
+  Con base en la geolocalización de la entrevista, determina el cluster (o sección)
 más cercano y le asigna el número de ese cluster. Para el diseno muestral esto implica
 que la entrevista fue levantada en el cluster más cercano a la geolocalización.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$correccion_cluster(base, shp, mantener, nivel, var_n)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{base}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{shp}}{Campo de la clase encuesta. contiene toda la información cartográfica de la
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$correccion_cluster(base, shp, mantener, nivel, var_n)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{base}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{shp}}{Campo de la clase encuesta. contiene toda la información cartográfica de la
 encuesta}
-
-\item{\code{mantener}}{Campo de la clase encuesta. Las entrevistas mantendrán el registro del
+      \item{\code{mantener}}{Campo de la clase encuesta. Las entrevistas mantendrán el registro del
 cluster en el cual hayan sido levantadas sin importas si hay otro cluster más cercano.}
-
-\item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
-
-\item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
+      \item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
+      \item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-eliminar_fuera_muestra"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-eliminar_fuera_muestra}{}}}
-\subsection{Method \code{eliminar_fuera_muestra()}}{
-Descarta las entrevistas cuyo cuyo cluster levantado no pertenezca a la lista
+\subsection{\code{Respuestas$eliminar_fuera_muestra()}}{
+  Descarta las entrevistas cuyo cuyo cluster levantado no pertenezca a la lista
 de clusters en muestra y notifica al usuario.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$eliminar_fuera_muestra(respuestas, muestra, nivel, var_n)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{respuestas}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
-
-\item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
-
-\item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$eliminar_fuera_muestra(respuestas, muestra, nivel, var_n)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{respuestas}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
+      \item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
+      \item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-calcular_distancia"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-calcular_distancia}{}}}
-\subsection{Method \code{calcular_distancia()}}{
-Calcula la distancia (en metros) entre la geolocalización donde se lvantó la
+\subsection{\code{Respuestas$calcular_distancia()}}{
+  Calcula la distancia (en metros) entre la geolocalización donde se lvantó la
 entrevista y el cluster más cercano que encuentre.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$calcular_distancia(base, encuesta, muestra, var_n, nivel)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{base}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{encuesta}}{Clase Encuesta de jerarquía mayor}
-
-\item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
-
-\item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$calcular_distancia(base, encuesta, muestra, var_n, nivel)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{base}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{encuesta}}{Clase Encuesta de jerarquía mayor}
+      \item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
+      \item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+      \item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-eliminar_faltantes_diseno"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-eliminar_faltantes_diseno}{}}}
-\subsection{Method \code{eliminar_faltantes_diseno()}}{
-Descartar entrevistas que por alguna razón u otra no se calculó la información
+\subsection{\code{Respuestas$eliminar_faltantes_diseno()}}{
+  Descartar entrevistas que por alguna razón u otra no se calculó la información
 relacionada a su diseño muestral
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$eliminar_faltantes_diseno()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$eliminar_faltantes_diseno()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-vars_diseno"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-vars_diseno}{}}}
-\subsection{Method \code{vars_diseno()}}{
-Agrega las variables relacionadas al diseno muestral
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$vars_diseno(muestra, var_n, tipo_encuesta)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
-
-\item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
+\subsection{\code{Respuestas$vars_diseno()}}{
+  Agrega las variables relacionadas al diseno muestral
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$vars_diseno(muestra, var_n, tipo_encuesta)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
+      \item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+      \item{\code{tipo_encuesta}}{Campo de la clase Encuesta que determina el tipo de encuesta levantada.}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{tipo_encuesta}}{Campo de la clase Encuesta que determina el tipo de encuesta levantada.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-retirar_no_efectivas"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-retirar_no_efectivas}{}}}
-\subsection{Method \code{retirar_no_efectivas()}}{
-Elimina las filas que no son efectivas
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$retirar_no_efectivas(respuestas)}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas$retirar_no_efectivas()}}{
+  Elimina las filas que no son efectivas
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$retirar_no_efectivas(respuestas)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{respuestas}}{Contiene la base de respuestas}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{respuestas}}{Contiene la base de respuestas}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Respuestas_proc.Rd
+++ b/man/Respuestas_proc.Rd
@@ -8,84 +8,83 @@ La clase \code{Respuestas} tiene como objetivo coonsolidar, limpiar y preparar l
 respuestas de los individuos entrevistados en campo.
 }
 \section{Super class}{
-\code{\link[encuestar:Preproceso]{encuestar::Preproceso}} -> \code{Respuestas_proc}
+\code{\link[encuestar:Preproceso]{Preproceso}} -> \code{Respuestas_proc}
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{eliminadas}}{El campo \code{eliminadas} contiene el \code{\link[=tibble]{tibble()}} de entrevistas eliminadas por
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{eliminadas}}{El campo \code{eliminadas} contiene el \code{\link[tibble:tibble]{tibble()}} de entrevistas eliminadas por
 auditoría.}
 
-\item{\code{cluster_corregido}}{El campo \code{cluster_corregido} contiene el \code{\link[=tibble]{tibble()}} de entrevistas cuyo
+    \item{\code{cluster_corregido}}{El campo \code{cluster_corregido} contiene el \code{\link[tibble:tibble]{tibble()}} de entrevistas cuyo
 cluster haya sido corregido por geolocalización.}
 
-\item{\code{base}}{El campo \code{base} contiene el \code{\link[=tibble]{tibble()}} de las respuestas serán utilizadas para construir
+    \item{\code{base}}{El campo \code{base} contiene el \code{\link[tibble:tibble]{tibble()}} de las respuestas serán utilizadas para construir
 el diseño muestral de la encuesta.}
 
-\item{\code{catalogo}}{El campo \code{catálogo} contiene el catálogo de variables en el cual se definen aqueelas
+    \item{\code{catalogo}}{El campo \code{catálogo} contiene el catálogo de variables en el cual se definen aqueelas
 que son necesarias y suficientes para construir un diseño muestral.}
 
-\item{\code{n}}{El campo \code{n} está en desuso.}
+    \item{\code{n}}{El campo \code{n} está en desuso.}
 
-\item{\code{m}}{El campo \code{m} está en desuso.}
+    \item{\code{m}}{El campo \code{m} está en desuso.}
 
-\item{\code{sin_coordenadas}}{El campo \code{sin_coordenadas} contiene el \code{\link[=tibble]{tibble()}} de, en caso de existir,
+    \item{\code{sin_coordenadas}}{El campo \code{sin_coordenadas} contiene el \code{\link[tibble:tibble]{tibble()}} de, en caso de existir,
 entrevistas que no tienen una geolicalización válida.}
 
-\item{\code{mantener_falta_coordenadas}}{\code{LOGICAL} determina si las entrevistas que no tienen una
+    \item{\code{mantener_falta_coordenadas}}{\code{LOGICAL} determina si las entrevistas que no tienen una
 geolocalización válida se descartan o no.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Active bindings}{
-\if{html}{\out{<div class="r6-active-bindings">}}
-\describe{
-\item{\code{mantener_falta_coordenadas}}{\code{LOGICAL} determina si las entrevistas que no tienen una
+  \if{html}{\out{<div class="r6-active-bindings">}}
+  \describe{
+    \item{\code{mantener_falta_coordenadas}}{\code{LOGICAL} determina si las entrevistas que no tienen una
 geolocalización válida se descartan o no.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Respuestas_proc-new}{\code{Respuestas_proc$new()}}
-\item \href{#method-Respuestas_proc-nombres}{\code{Respuestas_proc$nombres()}}
-\item \href{#method-Respuestas_proc-q_patron}{\code{Respuestas_proc$q_patron()}}
-\item \href{#method-Respuestas_proc-categorias}{\code{Respuestas_proc$categorias()}}
-\item \href{#method-Respuestas_proc-respuestas_sin_seleccion}{\code{Respuestas_proc$respuestas_sin_seleccion()}}
-\item \href{#method-Respuestas_proc-corregir_respuestas}{\code{Respuestas_proc$corregir_respuestas()}}
-\item \href{#method-Respuestas_proc-crear_variablesSecundarias}{\code{Respuestas_proc$crear_variablesSecundarias()}}
-\item \href{#method-Respuestas_proc-coordenadas_faltantes}{\code{Respuestas_proc$coordenadas_faltantes()}}
-\item \href{#method-Respuestas_proc-eliminar_falta_coordenadas}{\code{Respuestas_proc$eliminar_falta_coordenadas()}}
-\item \href{#method-Respuestas_proc-correccion_cluster}{\code{Respuestas_proc$correccion_cluster()}}
-\item \href{#method-Respuestas_proc-retirar_fuera_muestra}{\code{Respuestas_proc$retirar_fuera_muestra()}}
-\item \href{#method-Respuestas_proc-calcular_distancia}{\code{Respuestas_proc$calcular_distancia()}}
-\item \href{#method-Respuestas_proc-eliminar_faltantes_diseno}{\code{Respuestas_proc$eliminar_faltantes_diseno()}}
-\item \href{#method-Respuestas_proc-vars_diseno}{\code{Respuestas_proc$vars_diseno()}}
-\item \href{#method-Respuestas_proc-retirar_auditoria_telefonica}{\code{Respuestas_proc$retirar_auditoria_telefonica()}}
-\item \href{#method-Respuestas_proc-retirar_regla_eliminada}{\code{Respuestas_proc$retirar_regla_eliminada()}}
-\item \href{#method-Respuestas_proc-retirar_no_efectivas}{\code{Respuestas_proc$retirar_no_efectivas()}}
-\item \href{#method-Respuestas_proc-clone}{\code{Respuestas_proc$clone()}}
+  \itemize{
+    \item \href{#method-Respuestas_proc-initialize}{\code{Respuestas_proc$new()}}
+    \item \href{#method-Respuestas_proc-nombres}{\code{Respuestas_proc$nombres()}}
+    \item \href{#method-Respuestas_proc-q_patron}{\code{Respuestas_proc$q_patron()}}
+    \item \href{#method-Respuestas_proc-categorias}{\code{Respuestas_proc$categorias()}}
+    \item \href{#method-Respuestas_proc-respuestas_sin_seleccion}{\code{Respuestas_proc$respuestas_sin_seleccion()}}
+    \item \href{#method-Respuestas_proc-corregir_respuestas}{\code{Respuestas_proc$corregir_respuestas()}}
+    \item \href{#method-Respuestas_proc-crear_variablesSecundarias}{\code{Respuestas_proc$crear_variablesSecundarias()}}
+    \item \href{#method-Respuestas_proc-coordenadas_faltantes}{\code{Respuestas_proc$coordenadas_faltantes()}}
+    \item \href{#method-Respuestas_proc-eliminar_falta_coordenadas}{\code{Respuestas_proc$eliminar_falta_coordenadas()}}
+    \item \href{#method-Respuestas_proc-correccion_cluster}{\code{Respuestas_proc$correccion_cluster()}}
+    \item \href{#method-Respuestas_proc-retirar_fuera_muestra}{\code{Respuestas_proc$retirar_fuera_muestra()}}
+    \item \href{#method-Respuestas_proc-calcular_distancia}{\code{Respuestas_proc$calcular_distancia()}}
+    \item \href{#method-Respuestas_proc-eliminar_faltantes_diseno}{\code{Respuestas_proc$eliminar_faltantes_diseno()}}
+    \item \href{#method-Respuestas_proc-vars_diseno}{\code{Respuestas_proc$vars_diseno()}}
+    \item \href{#method-Respuestas_proc-retirar_auditoria_telefonica}{\code{Respuestas_proc$retirar_auditoria_telefonica()}}
+    \item \href{#method-Respuestas_proc-retirar_regla_eliminada}{\code{Respuestas_proc$retirar_regla_eliminada()}}
+    \item \href{#method-Respuestas_proc-retirar_no_efectivas}{\code{Respuestas_proc$retirar_no_efectivas()}}
+    \item \href{#method-Respuestas_proc-clone}{\code{Respuestas_proc$clone()}}
+  }
 }
-}
-\if{html}{\out{
-<details open><summary>Inherited methods</summary>
+\if{html}{\out{<details open><summary>Inherited methods</summary>
 <ul>
-<li><span class="pkg-link" data-pkg="encuestar" data-topic="Preproceso" data-id="actualizar_bd"><a href='../../encuestar/html/Preproceso.html#method-Preproceso-actualizar_bd'><code>encuestar::Preproceso$actualizar_bd()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="encuestar" data-topic="Preproceso" data-id="generar_diseno"><a href='../../encuestar/html/Preproceso.html#method-Preproceso-generar_diseno'><code>encuestar::Preproceso$generar_diseno()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="encuestar" data-topic="Preproceso" data-id="preparar_respuestas"><a href='../../encuestar/html/Preproceso.html#method-Preproceso-preparar_respuestas'><code>encuestar::Preproceso$preparar_respuestas()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="encuestar" data-topic="Preproceso" data-id="procesar_nuevas_entradas"><a href='../../encuestar/html/Preproceso.html#method-Preproceso-procesar_nuevas_entradas'><code>encuestar::Preproceso$procesar_nuevas_entradas()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="encuestar" data-topic="Preproceso" data-id="actualizar_bd"><a href='../../encuestar/html/Preproceso.html#method-Preproceso-actualizar_bd'><code>Preproceso$actualizar_bd()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="encuestar" data-topic="Preproceso" data-id="generar_diseno"><a href='../../encuestar/html/Preproceso.html#method-Preproceso-generar_diseno'><code>Preproceso$generar_diseno()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="encuestar" data-topic="Preproceso" data-id="preparar_respuestas"><a href='../../encuestar/html/Preproceso.html#method-Preproceso-preparar_respuestas'><code>Preproceso$preparar_respuestas()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="encuestar" data-topic="Preproceso" data-id="procesar_nuevas_entradas"><a href='../../encuestar/html/Preproceso.html#method-Preproceso-procesar_nuevas_entradas'><code>Preproceso$procesar_nuevas_entradas()</code></a></span></li>
 </ul>
-</details>
-}}
+</details>}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Respuestas_proc-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Respuestas_proc-new}{}}}
-\subsection{Method \code{new()}}{
-Se reciben los diferentes insumos relacionados a la encuesta para estandarizar
+\if{html}{\out{<a id="method-Respuestas_proc-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Respuestas_proc-initialize}{}}}
+\subsection{\code{Respuestas_proc$new()}}{
+  Se reciben los diferentes insumos relacionados a la encuesta para estandarizar
 las respuestas que formarán parte del diseÑo muestral.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$new(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$new(
   base = NULL,
   catalogo = NA,
   Preproceso = NULL,
@@ -93,344 +92,352 @@ las respuestas que formarán parte del diseÑo muestral.
   patron = NA,
   nivel = NULL,
   var_n = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{base}}{\code{\link[=tibble]{tibble()}} que contiene la base de datos de respuestas de las personas entrevistadas.}
-
-\item{\code{catalogo}}{\code{\link[=tibble]{tibble()}} que contiene el catalogo de variables.}
-
-\item{\code{muestra_completa}}{Objeto de formato personalizado generado por la paquetería \code{muestrear}.
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{base}}{\code{\link[tibble:tibble]{tibble()}} que contiene la base de datos de respuestas de las personas entrevistadas.}
+      \item{\code{catalogo}}{\code{\link[tibble:tibble]{tibble()}} que contiene el catalogo de variables.}
+      \item{\code{muestra_completa}}{Objeto de formato personalizado generado por la paquetería \code{muestrear}.
 Contiene el diseño muestral completo de la encuesta.}
-
-\item{\code{patron}}{Cadena de caracteres que se removerán de todas las respuestas recibidas en
+      \item{\code{patron}}{Cadena de caracteres que se removerán de todas las respuestas recibidas en
 campo.}
-
-\item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro.}
-
-\item{\code{var_n}}{Valor tipo caracter que indica el nombre de la variable asociado al último
+      \item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro.}
+      \item{\code{var_n}}{Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
-
-\item{\code{encuesta}}{Clase de jerarquía mayor.}
-
-\item{\code{mantener_falta_coordenadas}}{\code{LOGICAL} determina si las entrevistas que no tienen una
+      \item{\code{encuesta}}{Clase de jerarquía mayor.}
+      \item{\code{mantener_falta_coordenadas}}{\code{LOGICAL} determina si las entrevistas que no tienen una
 geolocalización válida se descartan o no.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-nombres"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-nombres}{}}}
-\subsection{Method \code{nombres()}}{
-Determina si la base de respuestas contiene todas las variables que, de acuerdo
+\subsection{\code{Respuestas_proc$nombres()}}{
+  Determina si la base de respuestas contiene todas las variables que, de acuerdo
 al diccionario, deben ser procesadas.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$nombres(catalogo_variables, bd, diccionario)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$nombres(catalogo_variables, bd, diccionario)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{catalogo_variables}}{\code{\link[tibble:tibble]{tibble()}} que contiene el catálogo de variables.}
+      \item{\code{bd}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{catalogo_variables}}{\code{\link[=tibble]{tibble()}} que contiene el catálogo de variables.}
-
-\item{\code{bd}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-q_patron"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-q_patron}{}}}
-\subsection{Method \code{q_patron()}}{
-Quita cadenas de texto de las respuetas de campo heredadas del cuestionario
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$q_patron(bd, dicc, patron)}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_proc$q_patron()}}{
+  Quita cadenas de texto de las respuetas de campo heredadas del cuestionario
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$q_patron(bd, dicc, patron)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{bd}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{dicc}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+      \item{\code{patron}}{Cadena o cadenas de texto que se desean quitar de las respuestas de campo}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{bd}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{dicc}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-
-\item{\code{patron}}{Cadena o cadenas de texto que se desean quitar de las respuestas de campo}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-categorias"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-categorias}{}}}
-\subsection{Method \code{categorias()}}{
-Determina diferencias entre las respuestas recolectadas en campo y las esperadas
+\subsection{\code{Respuestas_proc$categorias()}}{
+  Determina diferencias entre las respuestas recolectadas en campo y las esperadas
 de acuerdo al diccionario
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$categorias(bd, diccionario)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$categorias(bd, diccionario)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{bd}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{bd}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-respuestas_sin_seleccion"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-respuestas_sin_seleccion}{}}}
-\subsection{Method \code{respuestas_sin_seleccion()}}{
-Determina las respuestas esperadas que no han sido seleccionadas por los
+\subsection{\code{Respuestas_proc$respuestas_sin_seleccion()}}{
+  Determina las respuestas esperadas que no han sido seleccionadas por los
 entrevistados
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$respuestas_sin_seleccion(bd, diccionario)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$respuestas_sin_seleccion(bd, diccionario)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{bd}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{bd}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-corregir_respuestas"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-corregir_respuestas}{}}}
-\subsection{Method \code{corregir_respuestas()}}{
-Corrige las respuestas de los entrevistados de acuerdo a la base de correcciones
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$corregir_respuestas(respuestas, bd_correcciones_raw)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{respuestas}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{bd_correcciones_raw}}{\code{\link[=tibble]{tibble()}} que contiene la relación de entrevista, variable en la
+\subsection{\code{Respuestas_proc$corregir_respuestas()}}{
+  Corrige las respuestas de los entrevistados de acuerdo a la base de correcciones
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$corregir_respuestas(respuestas, bd_correcciones_raw)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{respuestas}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{bd_correcciones_raw}}{\code{\link[tibble:tibble]{tibble()}} que contiene la relación de entrevista, variable en la
 cual está incorrecto el registro y valor correcto de la respuesta}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-crear_variablesSecundarias"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-crear_variablesSecundarias}{}}}
-\subsection{Method \code{crear_variablesSecundarias()}}{
-Crea variables que, por defecto, se usan en la producción y entrega de resultados
+\subsection{\code{Respuestas_proc$crear_variablesSecundarias()}}{
+  Crea variables que, por defecto, se usan en la producción y entrega de resultados
 de Morant Consultores
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$crear_variablesSecundarias(diccionario)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$crear_variablesSecundarias(diccionario)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{diccionario}}{Diccionario (o codebook) del cuestionario de la encuesta.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-coordenadas_faltantes"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-coordenadas_faltantes}{}}}
-\subsection{Method \code{coordenadas_faltantes()}}{
-Determina las entrevistas con variables de geolocalización no válidas
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$coordenadas_faltantes()}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_proc$coordenadas_faltantes()}}{
+  Determina las entrevistas con variables de geolocalización no válidas
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$coordenadas_faltantes()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-eliminar_falta_coordenadas"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-eliminar_falta_coordenadas}{}}}
-\subsection{Method \code{eliminar_falta_coordenadas()}}{
-Descarta y registra las entrevistas con variables de geolocalización no válidas
+\subsection{\code{Respuestas_proc$eliminar_falta_coordenadas()}}{
+  Descarta y registra las entrevistas con variables de geolocalización no válidas
 y comunica al usuario esa operación
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$eliminar_falta_coordenadas()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$eliminar_falta_coordenadas()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-correccion_cluster"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-correccion_cluster}{}}}
-\subsection{Method \code{correccion_cluster()}}{
-Con base en la geolocalización de la entrevista, determina el cluster (o sección)
+\subsection{\code{Respuestas_proc$correccion_cluster()}}{
+  Con base en la geolocalización de la entrevista, determina el cluster (o sección)
 más cercano y le asigna el número de ese cluster. Para el diseno muestral esto implica
 que la entrevista fue levantada en el cluster más cercano a la geolocalización.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$correccion_cluster(base, shp, mantener, nivel, var_n)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{base}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{shp}}{Campo de la clase encuesta. contiene toda la información cartográfica de la
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$correccion_cluster(base, shp, mantener, nivel, var_n)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{base}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{shp}}{Campo de la clase encuesta. contiene toda la información cartográfica de la
 encuesta}
-
-\item{\code{mantener}}{Campo de la clase encuesta. Las entrevistas mantendrán el registro del
+      \item{\code{mantener}}{Campo de la clase encuesta. Las entrevistas mantendrán el registro del
 cluster en el cual hayan sido levantadas sin importas si hay otro cluster más cercano.}
-
-\item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
-
-\item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
+      \item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
+      \item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-retirar_fuera_muestra"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-retirar_fuera_muestra}{}}}
-\subsection{Method \code{retirar_fuera_muestra()}}{
-Descarta las entrevistas cuyo cuyo cluster levantado no pertenezca a la lista
+\subsection{\code{Respuestas_proc$retirar_fuera_muestra()}}{
+  Descarta las entrevistas cuyo cuyo cluster levantado no pertenezca a la lista
 de clusters en muestra y notifica al usuario.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$retirar_fuera_muestra(respuestas, muestra, nivel, var_n)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{respuestas}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
-
-\item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
-
-\item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$retirar_fuera_muestra(respuestas, muestra, nivel, var_n)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{respuestas}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
+      \item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
+      \item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-calcular_distancia"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-calcular_distancia}{}}}
-\subsection{Method \code{calcular_distancia()}}{
-Calcula la distancia (en metros) entre la geolocalización donde se lvantó la
+\subsection{\code{Respuestas_proc$calcular_distancia()}}{
+  Calcula la distancia (en metros) entre la geolocalización donde se lvantó la
 entrevista y el cluster más cercano que encuentre.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$calcular_distancia(base, encuesta, muestra, var_n, nivel)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{base}}{\code{\link[=tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
-
-\item{\code{encuesta}}{Clase Encuesta de jerarquía mayor}
-
-\item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
-
-\item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$calcular_distancia(base, encuesta, muestra, var_n, nivel)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{base}}{\code{\link[tibble:tibble]{tibble()}} que contiene las respuestas recolectadas en campo}
+      \item{\code{encuesta}}{Clase Encuesta de jerarquía mayor}
+      \item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
+      \item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+      \item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{nivel}}{Valor tipo entero que indica el número de etapas de muestro}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-eliminar_faltantes_diseno"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-eliminar_faltantes_diseno}{}}}
-\subsection{Method \code{eliminar_faltantes_diseno()}}{
-Descartar entrevistas que por alguna razón u otra no se calculó la información
+\subsection{\code{Respuestas_proc$eliminar_faltantes_diseno()}}{
+  Descartar entrevistas que por alguna razón u otra no se calculó la información
 relacionada a su diseño muestral
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$eliminar_faltantes_diseno()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$eliminar_faltantes_diseno()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-vars_diseno"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-vars_diseno}{}}}
-\subsection{Method \code{vars_diseno()}}{
-Agrega las variables relacionadas al diseno muestral
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$vars_diseno(muestra, var_n, tipo_encuesta)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
-
-\item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
+\subsection{\code{Respuestas_proc$vars_diseno()}}{
+  Agrega las variables relacionadas al diseno muestral
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$vars_diseno(muestra, var_n, tipo_encuesta)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
+      \item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+      \item{\code{tipo_encuesta}}{Campo de la clase Encuesta que determina el tipo de encuesta levantada.}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{tipo_encuesta}}{Campo de la clase Encuesta que determina el tipo de encuesta levantada.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-retirar_auditoria_telefonica"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-retirar_auditoria_telefonica}{}}}
-\subsection{Method \code{retirar_auditoria_telefonica()}}{
-Retira las entrevistas que son eliminadas por auditoria
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$retirar_auditoria_telefonica()}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_proc$retirar_auditoria_telefonica()}}{
+  Retira las entrevistas que son eliminadas por auditoria
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$retirar_auditoria_telefonica()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-retirar_regla_eliminada"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-retirar_regla_eliminada}{}}}
-\subsection{Method \code{retirar_regla_eliminada()}}{
-Retira las entrevistas que son eliminadas por regla
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$retirar_regla_eliminada()}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_proc$retirar_regla_eliminada()}}{
+  Retira las entrevistas que son eliminadas por regla
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$retirar_regla_eliminada()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-retirar_no_efectivas"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-retirar_no_efectivas}{}}}
-\subsection{Method \code{retirar_no_efectivas()}}{
-Elimina las filas que no son efectivas
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$retirar_no_efectivas(respuestas)}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_proc$retirar_no_efectivas()}}{
+  Elimina las filas que no son efectivas
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$retirar_no_efectivas(respuestas)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{respuestas}}{Contiene la base de respuestas}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{respuestas}}{Contiene la base de respuestas}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_proc-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_proc-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_proc$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_proc$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_proc$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Respuestas_svy.Rd
+++ b/man/Respuestas_svy.Rd
@@ -11,205 +11,221 @@ de clasificadoras de métodos. De esta forma, la clase \code{Resultados} escenci
 procesat y visualizar.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{encuesta}}{Clase de jerarquía superior. Campo heredado por la clase \code{Encuesta}.}
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{encuesta}}{Clase de jerarquía superior. Campo heredado por la clase \code{Encuesta}.}
 
-\item{\code{diseno}}{Diseno muestral actual. Aunque el diseno esté contenido en la clase \code{Encuesta},
+    \item{\code{diseno}}{Diseno muestral actual. Aunque el diseno esté contenido en la clase \code{Encuesta},
 el modo de procesamiento de encuesta que no se levantó en campo requiere de alimentar la clase
 \code{Resultados} con un diseno muestral independiente a la clase \code{Muestra}.}
 
-\item{\code{diccionario}}{Diccionario de procesamiento. Aunque el diccionario esté contendio en la
+    \item{\code{diccionario}}{Diccionario de procesamiento. Aunque el diccionario esté contendio en la
 clase \code{Cuestionario} que a su vez está dentro de la clase \code{Encuesta} el modo de procesamiento de
 encuesta que no se levantói en campo requiere de alimentar la clase con un diccionario que no
 haya sido procesado por la clase \code{Cuestionario}.}
 
-\item{\code{Descriptiva}}{Clase de jerarquía menor. Contiene los métodos que visualizan resultados de
+    \item{\code{Descriptiva}}{Clase de jerarquía menor. Contiene los métodos que visualizan resultados de
 forma más simple como gráficas de barras de resultados de una sola variable.}
 
-\item{\code{Regiones}}{Clase de jerarquía menor, Contiene los métodos que visualizan resultados basados
+    \item{\code{Regiones}}{Clase de jerarquía menor, Contiene los métodos que visualizan resultados basados
 en la estratificación de la encuesta.}
 
-\item{\code{Modelo}}{Clase de jerarquía menor. Contiene métodos de análisis estadísitico como PCA.}
+    \item{\code{Modelo}}{Clase de jerarquía menor. Contiene métodos de análisis estadísitico como PCA.}
 
-\item{\code{Cruce}}{Clase de jerarquía menor. Contiene métodos enfocados en presentar resultados
+    \item{\code{Cruce}}{Clase de jerarquía menor. Contiene métodos enfocados en presentar resultados
 cruzando dos o más variables.}
 
-\item{\code{Especial}}{Clase de jerarquía menor. Contiene métodos para visualizar resultados construidos
+    \item{\code{Especial}}{Clase de jerarquía menor. Contiene métodos para visualizar resultados construidos
 de forma personalizada.}
 
-\item{\code{Tendencias}}{Clase de jerarquía menor. Contiene los metodos de estimacions usando la media móvil}
+    \item{\code{Tendencias}}{Clase de jerarquía menor. Contiene los metodos de estimacions usando la media móvil}
 
-\item{\code{tema}}{Objeto \link{theme} de la paquetería \link{ggplot2} que contiene el formato e identidad gráfica
+    \item{\code{tema}}{Objeto \link[ggplot2:theme]{theme} de la paquetería \link[ggplot2:ggplot2]{ggplot2} que contiene el formato e identidad gráfica
 de Morant Consultores}
 
-\item{\code{graficadas}}{En desuso. Contiene un \link{ tibble} que indica qué variables ya han sido procesadas
+    \item{\code{graficadas}}{En desuso. Contiene un \link{ tibble} que indica qué variables ya han sido procesadas
 durante la producción.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Active bindings}{
-\if{html}{\out{<div class="r6-active-bindings">}}
-\describe{
-\item{\code{encuesta}}{Clase de jerarquía superior. Campo heredado por la clase \code{Encuesta}.}
+  \if{html}{\out{<div class="r6-active-bindings">}}
+  \describe{
+    \item{\code{encuesta}}{Clase de jerarquía superior. Campo heredado por la clase \code{Encuesta}.}
 
-\item{\code{diseno}}{Diseno muestral actual. Aunque el diseno esté contenido en la clase \code{Encuesta},
+    \item{\code{diseno}}{Diseno muestral actual. Aunque el diseno esté contenido en la clase \code{Encuesta},
 el modo de procesamiento de encuesta que no se levantó en campo requiere de alimentar la clase
 \code{Resultados} con un diseno muestral independiente a la clase \code{Muestra}.}
 
-\item{\code{diccionario}}{Diccionario de procesamiento. Aunque el diccionario esté contendio en la
+    \item{\code{diccionario}}{Diccionario de procesamiento. Aunque el diccionario esté contendio en la
 clase \code{Cuestionario} que a su vez está dentro de la clase \code{Encuesta} el modo de procesamiento de
 encuesta que no se levantói en campo requiere de alimentar la clase con un diccionario que no
 haya sido procesado por la clase \code{Cuestionario}.}
 
-\item{\code{Descriptiva}}{Clase de jerarquía menor. Contiene los métodos que visualizan resultados de
+    \item{\code{Descriptiva}}{Clase de jerarquía menor. Contiene los métodos que visualizan resultados de
 forma más simple como gráficas de barras de resultados de una sola variable.}
 
-\item{\code{Regiones}}{Clase de jerarquía menor, Contiene los métodos que visualizan resultados basados
+    \item{\code{Regiones}}{Clase de jerarquía menor, Contiene los métodos que visualizan resultados basados
 en la estratificación de la encuesta.}
 
-\item{\code{Modelo}}{Clase de jerarquía menor. Contiene métodos de análisis estadísitico como PCA.}
+    \item{\code{Modelo}}{Clase de jerarquía menor. Contiene métodos de análisis estadísitico como PCA.}
 
-\item{\code{Cruce}}{Clase de jerarquía menor. Contiene métodos enfocados en presentar resultados
+    \item{\code{Cruce}}{Clase de jerarquía menor. Contiene métodos enfocados en presentar resultados
 cruzando dos o más variables.}
 
-\item{\code{Especial}}{Clase de jerarquía menor. Contiene métodos para visualizar resultados construidos
+    \item{\code{Especial}}{Clase de jerarquía menor. Contiene métodos para visualizar resultados construidos
 de forma personalizada.}
 
-\item{\code{Tendencias}}{Clase de jerarquía menor. Contiene los metodos de estimacions usando la media móvil}
+    \item{\code{Tendencias}}{Clase de jerarquía menor. Contiene los metodos de estimacions usando la media móvil}
 
-\item{\code{tema}}{Objeto \link{theme} de la paquetería \link{ggplot2} que contiene el formato e identidad gráfica
+    \item{\code{tema}}{Objeto \link[ggplot2:theme]{theme} de la paquetería \link[ggplot2:ggplot2]{ggplot2} que contiene el formato e identidad gráfica
 de Morant Consultores}
 
-\item{\code{graficadas}}{En desuso. Contiene un \link{ tibble} que indica qué variables ya han sido procesadas
+    \item{\code{graficadas}}{En desuso. Contiene un \link{ tibble} que indica qué variables ya han sido procesadas
 durante la producción.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Respuestas_svy-new}{\code{Respuestas_svy$new()}}
-\item \href{#method-Respuestas_svy-obtener_eliminadas_auditorias}{\code{Respuestas_svy$obtener_eliminadas_auditorias()}}
-\item \href{#method-Respuestas_svy-obtener_eliminadas_regla}{\code{Respuestas_svy$obtener_eliminadas_regla()}}
-\item \href{#method-Respuestas_svy-obtener_eliminadas_no_efectivas}{\code{Respuestas_svy$obtener_eliminadas_no_efectivas()}}
-\item \href{#method-Respuestas_svy-obtener_eliminadas_sin_coordenadas}{\code{Respuestas_svy$obtener_eliminadas_sin_coordenadas()}}
-\item \href{#method-Respuestas_svy-obtener_fuera_muestra}{\code{Respuestas_svy$obtener_fuera_muestra()}}
-\item \href{#method-Respuestas_svy-obtener_fuera_otros}{\code{Respuestas_svy$obtener_fuera_otros()}}
-\item \href{#method-Respuestas_svy-vars_diseno}{\code{Respuestas_svy$vars_diseno()}}
-\item \href{#method-Respuestas_svy-clone}{\code{Respuestas_svy$clone()}}
-}
+  \itemize{
+    \item \href{#method-Respuestas_svy-initialize}{\code{Respuestas_svy$new()}}
+    \item \href{#method-Respuestas_svy-obtener_eliminadas_auditorias}{\code{Respuestas_svy$obtener_eliminadas_auditorias()}}
+    \item \href{#method-Respuestas_svy-obtener_eliminadas_regla}{\code{Respuestas_svy$obtener_eliminadas_regla()}}
+    \item \href{#method-Respuestas_svy-obtener_eliminadas_no_efectivas}{\code{Respuestas_svy$obtener_eliminadas_no_efectivas()}}
+    \item \href{#method-Respuestas_svy-obtener_eliminadas_sin_coordenadas}{\code{Respuestas_svy$obtener_eliminadas_sin_coordenadas()}}
+    \item \href{#method-Respuestas_svy-obtener_fuera_muestra}{\code{Respuestas_svy$obtener_fuera_muestra()}}
+    \item \href{#method-Respuestas_svy-obtener_fuera_otros}{\code{Respuestas_svy$obtener_fuera_otros()}}
+    \item \href{#method-Respuestas_svy-vars_diseno}{\code{Respuestas_svy$vars_diseno()}}
+    \item \href{#method-Respuestas_svy-clone}{\code{Respuestas_svy$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Respuestas_svy-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Respuestas_svy-new}{}}}
-\subsection{Method \code{new()}}{
-Toma los datos de la base procesada y los va separando para su lectura.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_svy$new(bd_respuestas)}\if{html}{\out{</div>}}
+\if{html}{\out{<a id="method-Respuestas_svy-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Respuestas_svy-initialize}{}}}
+\subsection{\code{Respuestas_svy$new()}}{
+  Toma los datos de la base procesada y los va separando para su lectura.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_svy$new(bd_respuestas)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{bd_respuestas}}{Base de datos que carga los datos previamente procesados}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{bd_respuestas}}{Base de datos que carga los datos previamente procesados}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_svy-obtener_eliminadas_auditorias"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_svy-obtener_eliminadas_auditorias}{}}}
-\subsection{Method \code{obtener_eliminadas_auditorias()}}{
-Visualiza las variables que aún no han sido producidas
+\subsection{\code{Respuestas_svy$obtener_eliminadas_auditorias()}}{
+  Visualiza las variables que aún no han sido producidas
 por la paqutería durante la producción.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_svy$obtener_eliminadas_auditorias()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_svy$obtener_eliminadas_auditorias()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_svy-obtener_eliminadas_regla"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_svy-obtener_eliminadas_regla}{}}}
-\subsection{Method \code{obtener_eliminadas_regla()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_svy$obtener_eliminadas_regla()}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_svy$obtener_eliminadas_regla()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_svy$obtener_eliminadas_regla()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_svy-obtener_eliminadas_no_efectivas"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_svy-obtener_eliminadas_no_efectivas}{}}}
-\subsection{Method \code{obtener_eliminadas_no_efectivas()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_svy$obtener_eliminadas_no_efectivas()}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_svy$obtener_eliminadas_no_efectivas()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_svy$obtener_eliminadas_no_efectivas()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_svy-obtener_eliminadas_sin_coordenadas"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_svy-obtener_eliminadas_sin_coordenadas}{}}}
-\subsection{Method \code{obtener_eliminadas_sin_coordenadas()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_svy$obtener_eliminadas_sin_coordenadas()}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_svy$obtener_eliminadas_sin_coordenadas()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_svy$obtener_eliminadas_sin_coordenadas()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_svy-obtener_fuera_muestra"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_svy-obtener_fuera_muestra}{}}}
-\subsection{Method \code{obtener_fuera_muestra()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_svy$obtener_fuera_muestra()}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_svy$obtener_fuera_muestra()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_svy$obtener_fuera_muestra()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_svy-obtener_fuera_otros"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_svy-obtener_fuera_otros}{}}}
-\subsection{Method \code{obtener_fuera_otros()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_svy$obtener_fuera_otros()}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_svy$obtener_fuera_otros()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_svy$obtener_fuera_otros()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_svy-vars_diseno"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_svy-vars_diseno}{}}}
-\subsection{Method \code{vars_diseno()}}{
-Agrega las variables relacionadas al diseno muestral
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_svy$vars_diseno(muestra, var_n, tipo_encuesta)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
-
-\item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
+\subsection{\code{Respuestas_svy$vars_diseno()}}{
+  Agrega las variables relacionadas al diseno muestral
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_svy$vars_diseno(muestra, var_n, tipo_encuesta)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{muestra}}{Contiene el diseño muestral completo de la encuesta.}
+      \item{\code{var_n}}{var_n Valor tipo caracter que indica el nombre de la variable asociado al último
 nivel de la etapa de muestreo.}
+      \item{\code{tipo_encuesta}}{Campo de la clase Encuesta que determina el tipo de encuesta levantada.}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{tipo_encuesta}}{Campo de la clase Encuesta que determina el tipo de encuesta levantada.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Respuestas_svy-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Respuestas_svy-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Respuestas_svy$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Respuestas_svy$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Respuestas_svy$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Resultados.Rd
+++ b/man/Resultados.Rd
@@ -11,105 +11,108 @@ de clasificadoras de métodos. De esta forma, la clase \code{Resultados} escenci
 procesat y visualizar.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{encuesta}}{Clase de jerarquía superior. Campo heredado por la clase \code{Encuesta}.}
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{encuesta}}{Clase de jerarquía superior. Campo heredado por la clase \code{Encuesta}.}
 
-\item{\code{diseno}}{Diseno muestral actual. Aunque el diseno esté contenido en la clase \code{Encuesta},
+    \item{\code{diseno}}{Diseno muestral actual. Aunque el diseno esté contenido en la clase \code{Encuesta},
 el modo de procesamiento de encuesta que no se levantó en campo requiere de alimentar la clase
 \code{Resultados} con un diseno muestral independiente a la clase \code{Muestra}.}
 
-\item{\code{diccionario}}{Diccionario de procesamiento. Aunque el diccionario esté contendio en la
+    \item{\code{diccionario}}{Diccionario de procesamiento. Aunque el diccionario esté contendio en la
 clase \code{Cuestionario} que a su vez está dentro de la clase \code{Encuesta} el modo de procesamiento de
 encuesta que no se levantói en campo requiere de alimentar la clase con un diccionario que no
 haya sido procesado por la clase \code{Cuestionario}.}
 
-\item{\code{Descriptiva}}{Clase de jerarquía menor. Contiene los métodos que visualizan resultados de
+    \item{\code{Descriptiva}}{Clase de jerarquía menor. Contiene los métodos que visualizan resultados de
 forma más simple como gráficas de barras de resultados de una sola variable.}
 
-\item{\code{Regiones}}{Clase de jerarquía menor, Contiene los métodos que visualizan resultados basados
+    \item{\code{Regiones}}{Clase de jerarquía menor, Contiene los métodos que visualizan resultados basados
 en la estratificación de la encuesta.}
 
-\item{\code{Modelo}}{Clase de jerarquía menor. Contiene métodos de análisis estadísitico como PCA.}
+    \item{\code{Modelo}}{Clase de jerarquía menor. Contiene métodos de análisis estadísitico como PCA.}
 
-\item{\code{Cruce}}{Clase de jerarquía menor. Contiene métodos enfocados en presentar resultados
+    \item{\code{Cruce}}{Clase de jerarquía menor. Contiene métodos enfocados en presentar resultados
 cruzando dos o más variables.}
 
-\item{\code{Especial}}{Clase de jerarquía menor. Contiene métodos para visualizar resultados construidos
+    \item{\code{Especial}}{Clase de jerarquía menor. Contiene métodos para visualizar resultados construidos
 de forma personalizada.}
 
-\item{\code{Tendencias}}{Clase de jerarquía menor. Contiene los metodos de estimacions usando la media móvil}
+    \item{\code{Tendencias}}{Clase de jerarquía menor. Contiene los metodos de estimacions usando la media móvil}
 
-\item{\code{tema}}{Objeto \link{theme} de la paquetería \link{ggplot2} que contiene el formato e identidad gráfica
+    \item{\code{tema}}{Objeto \link[ggplot2:theme]{theme} de la paquetería \link[ggplot2:ggplot2]{ggplot2} que contiene el formato e identidad gráfica
 de Morant Consultores}
 
-\item{\code{graficadas}}{En desuso. Contiene un \link{ tibble} que indica qué variables ya han sido procesadas
+    \item{\code{graficadas}}{En desuso. Contiene un \link{ tibble} que indica qué variables ya han sido procesadas
 durante la producción.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Resultados-new}{\code{Resultados$new()}}
-\item \href{#method-Resultados-faltantes}{\code{Resultados$faltantes()}}
-\item \href{#method-Resultados-clone}{\code{Resultados$clone()}}
-}
+  \itemize{
+    \item \href{#method-Resultados-initialize}{\code{Resultados$new()}}
+    \item \href{#method-Resultados-faltantes}{\code{Resultados$faltantes()}}
+    \item \href{#method-Resultados-clone}{\code{Resultados$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Resultados-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Resultados-new}{}}}
-\subsection{Method \code{new()}}{
-Carga los insumos necesarios para producir resultados en
-forma de visualizaciones con objetos tipo \link{ggplot2} o \link{flextable}
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Resultados$new(encuesta, diseno, diccionario, tema = tema_morant())}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{encuesta}}{Clase de jerarquía superior que se carga de forma
+\if{html}{\out{<a id="method-Resultados-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Resultados-initialize}{}}}
+\subsection{\code{Resultados$new()}}{
+  Carga los insumos necesarios para producir resultados en
+forma de visualizaciones con objetos tipo \link[ggplot2:ggplot2]{ggplot2} o \link{flextable}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Resultados$new(encuesta, diseno, diccionario, tema = tema_morant())}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{encuesta}}{Clase de jerarquía superior que se carga de forma
 implítica.}
-
-\item{\code{diseno}}{Objeto tipo \link{desing} de la paquetería \link{survey}. Si el
+      \item{\code{diseno}}{Objeto tipo \link{desing} de la paquetería \link{survey}. Si el
 parámetro es no nullo, el objeto \code{diseno} es el usado para calcular
 las estimaciones. No se espera que ambos parámetros \code{encuesta} y
 \code{diseno} sean no nulos al mismo tiempo.}
+      \item{\code{diccionario}}{Diccionario de procesamiento de la encuesta.}
+      \item{\code{tema}}{Objetio tipo \link[ggplot2:theme]{theme} de la paquetería \link[ggplot2:ggplot2]{ggplot2}.}
+    }
+    \if{html}{\out{</div>}}
+  }
+}
 
-\item{\code{diccionario}}{Diccionario de procesamiento de la encuesta.}
-
-\item{\code{tema}}{Objetio tipo \link{theme} de la paquetería \link{ggplot2}.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Resultados-faltantes"></a>}}
 \if{latex}{\out{\hypertarget{method-Resultados-faltantes}{}}}
-\subsection{Method \code{faltantes()}}{
-Visualiza las variables que aún no han sido producidas
+\subsection{\code{Resultados$faltantes()}}{
+  Visualiza las variables que aún no han sido producidas
 por la paqutería durante la producción.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Resultados$faltantes()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Resultados$faltantes()}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Resultados-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Resultados-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Resultados$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Resultados$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Resultados$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Survey_analisis.Rd
+++ b/man/Survey_analisis.Rd
@@ -10,93 +10,94 @@ relacionada al levantamiento, respuestas y equipo que trabaja en campo. La clase
 cinco clases subordinadas: \code{Cuestionario}, \code{Respuestas}, \code{Muestra}, \code{Resultados} y \code{Auditoria}.
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{muestra}}{El campo \code{muestra} contiene los resultados de ejecutar la clase \code{Muestra} de
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{muestra}}{El campo \code{muestra} contiene los resultados de ejecutar la clase \code{Muestra} de
 jerarquía menor. Dicha clase contiene el diseño muestral calculado a partir de la edad, sexo y
 geolocalización de los individuos entrevistados. Además del diseño muestral contiene métodos para
 modificar dicho diseño a partir de postestratificaciones o filtrar a través de subconjuntos de
 la muestra.}
 
-\item{\code{shp}}{El campo \code{shp} contiene la cartografía de los clusters que hayan sido seleccionados en
+    \item{\code{shp}}{El campo \code{shp} contiene la cartografía de los clusters que hayan sido seleccionados en
 el proceso de muestreo.}
 
-\item{\code{cuestionario}}{El campo \code{cuestionario} contiene los resultados de ejecutar la clase
+    \item{\code{cuestionario}}{El campo \code{cuestionario} contiene los resultados de ejecutar la clase
 \code{Cuestionario}. Dicha clase originalmente recibía el texto y las clases asociadas al cuestinoario
-en formato .docx y generaba el diccionario. Actualmente la clase recibe y asigna el \code{\link[=tibble]{tibble()}}
+en formato .docx y generaba el diccionario. Actualmente la clase recibe y asigna el \code{\link[tibble:tibble]{tibble()}}
 que contiene el diccionario y realiza unas cuantas verificaciones.}
 
-\item{\code{respuestas}}{El campo \code{respuestas} contiene los resultados de ejecutar la clase \code{Respuestas}
+    \item{\code{respuestas}}{El campo \code{respuestas} contiene los resultados de ejecutar la clase \code{Respuestas}
 de jerarquía menor. Dicha clase tiene como objetivo verificar, limpiar y estandarizar las
 respuestas recibidas de campo.}
 
-\item{\code{n_simulaciones}}{Valor entero usado para simular un \code{\link[=tibble]{tibble()}} necesario para generar
+    \item{\code{n_simulaciones}}{Valor entero usado para simular un \code{\link[tibble:tibble]{tibble()}} necesario para generar
 la clase \code{Respuestas}.}
 
-\item{\code{opinometro_id}}{Valor entero usado para generar el \code{\link[=tibble]{tibble()}} de respuestas a través
+    \item{\code{opinometro_id}}{Valor entero usado para generar el \code{\link[tibble:tibble]{tibble()}} de respuestas a través
 de la plataforma Opinómetro y que es necesario para generar la clase \code{Respuestas}.}
 
-\item{\code{pool}}{El campo \code{pool} se hereda para ser usado por la clase \code{Opinómetro}.}
+    \item{\code{pool}}{El campo \code{pool} se hereda para ser usado por la clase \code{Opinómetro}.}
 
-\item{\code{bd_categorias}}{El \code{\link[=tibble]{tibble()}} que contiene las categoriías generadas por IA se une al
-\code{\link[=tibble]{tibble()}} \code{respuestas} independientemente si el segundo es del campo \code{respuestas} o
+    \item{\code{bd_categorias}}{El \code{\link[tibble:tibble]{tibble()}} que contiene las categoriías generadas por IA se une al
+\code{\link[tibble:tibble]{tibble()}} \code{respuestas} independientemente si el segundo es del campo \code{respuestas} o
 generado por opinómetro.}
 
-\item{\code{bd_correcciones}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{bd_correcciones}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{patron}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{patron}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{auditoria_telefonica}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{auditoria_telefonica}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{quitar_vars}}{\code{DEPRECATED} en futuro desuso.}
+    \item{\code{quitar_vars}}{\code{DEPRECATED} en futuro desuso.}
 
-\item{\code{mantener}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{mantener}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{auditar}}{El campo se queda guardado en la clase \code{Encuesta} para su uso en la aplicación
+    \item{\code{auditar}}{El campo se queda guardado en la clase \code{Encuesta} para su uso en la aplicación
 de monitoreo del levantamiento.}
 
-\item{\code{vars_tendencias}}{El campo se queda guardado en la clase \code{Encuesta} para su uso en la
+    \item{\code{vars_tendencias}}{El campo se queda guardado en la clase \code{Encuesta} para su uso en la
 aplicación de monitoreo del levantamiento.}
 
-\item{\code{sin_peso}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{sin_peso}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{rake}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{rake}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{mantener_falta_coordenadas}}{El campo se hereda a la clase \code{Respuestas}.}
+    \item{\code{mantener_falta_coordenadas}}{El campo se hereda a la clase \code{Respuestas}.}
 
-\item{\code{tipo_encuesta}}{Por defecto se imputa que el tipo de encuesta sea \code{ine}.}
+    \item{\code{tipo_encuesta}}{Por defecto se imputa que el tipo de encuesta sea \code{ine}.}
 
-\item{\code{shp_completo}}{Extensión del campo \code{shp}. Una vez calculadas las entrevistas efectivas y
+    \item{\code{shp_completo}}{Extensión del campo \code{shp}. Una vez calculadas las entrevistas efectivas y
 asignadas las ponderaciones. Se determinan las ubicaciones puntuales donde se levantaron las
 entrevistas y se agrega al objeto \code{shp}.}
 
-\item{\code{Resultados}}{Clase subordinada. La clase \code{Resultados} contiene todos los método utilizados
+    \item{\code{Resultados}}{Clase subordinada. La clase \code{Resultados} contiene todos los método utilizados
 para generar el entregable final.}
 
-\item{\code{Auditoria}}{Clase subordinada. La clase \code{Auditoria} en su mayor parte escribe el script de
+    \item{\code{Auditoria}}{Clase subordinada. La clase \code{Auditoria} en su mayor parte escribe el script de
 la aplicación de monitorio de en un \code{folder} llamado \code{auditoria} en el \verb{working directory}.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Survey_analisis-new}{\code{Survey_analisis$new()}}
-\item \href{#method-Survey_analisis-simular_surveytogo}{\code{Survey_analisis$simular_surveytogo()}}
-\item \href{#method-Survey_analisis-error_muestral_maximo}{\code{Survey_analisis$error_muestral_maximo()}}
-\item \href{#method-Survey_analisis-exportar_entregable}{\code{Survey_analisis$exportar_entregable()}}
-\item \href{#method-Survey_analisis-clone}{\code{Survey_analisis$clone()}}
-}
+  \itemize{
+    \item \href{#method-Survey_analisis-initialize}{\code{Survey_analisis$new()}}
+    \item \href{#method-Survey_analisis-simular_surveytogo}{\code{Survey_analisis$simular_surveytogo()}}
+    \item \href{#method-Survey_analisis-error_muestral_maximo}{\code{Survey_analisis$error_muestral_maximo()}}
+    \item \href{#method-Survey_analisis-exportar_entregable}{\code{Survey_analisis$exportar_entregable()}}
+    \item \href{#method-Survey_analisis-clone}{\code{Survey_analisis$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Survey_analisis-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Survey_analisis-new}{}}}
-\subsection{Method \code{new()}}{
-Se reciben los insumos de respuestas, auditoria y otros parámetros asociados
+\if{html}{\out{<a id="method-Survey_analisis-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Survey_analisis-initialize}{}}}
+\subsection{\code{Survey_analisis$new()}}{
+  Se reciben los insumos de respuestas, auditoria y otros parámetros asociados
 al levantamiento de la encuesta para construir el diseño muestral y las clases posteriores
 para generar resultados.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Survey_analisis$new(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Survey_analisis$new(
   muestra = NA,
   shp = NA,
   cuestionario = NA,
@@ -114,163 +115,149 @@ para generar resultados.
   sin_peso = FALSE,
   rake = TRUE,
   tipo_encuesta = "ine"
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{muestra}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Es el diseño muestral
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{muestra}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Es el diseño muestral
 de la encuesta. El dobjeto \code{muestra} es de formato personalizado por lo que no es posible
 (o práctico) sustituirlo.}
-
-\item{\code{shp}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Contiene toda la
+      \item{\code{shp}}{Objeto tipo \code{.rda} generado por la paquetería \code{muestrear}. Contiene toda la
 cartografía utilizada para el equipo de campo y que a su vez es utilizada por la aplicación
 de monitoreo del levantamiento. El objeto \code{shp} es de formato personalizado por lo que no
 es posible (o práctico) sustituirlo.}
-
-\item{\code{cuestionario}}{\code{\link[=tibble]{tibble()}} que es el diccionario del cuestionario que se aplica a los
+      \item{\code{cuestionario}}{\code{\link[tibble:tibble]{tibble()}} que es el diccionario del cuestionario que se aplica a los
 entrevistados. El parámetro \code{cuestionario}, después de una actualización, actúa como el
 diccionario (o codebbok).}
-
-\item{\code{n_simulaciones}}{Valor entero. Con el objetivo de publicar la aplicación de monitoreio
+      \item{\code{n_simulaciones}}{Valor entero. Con el objetivo de publicar la aplicación de monitoreio
 antes de inciar el levantamiento es posible simular una base de respuestas.
 \code{n_simulaciones} es el total de respuestas simuladas, es decir, es el \code{\link[=nrow]{nrow()}} que simula
 al campo \code{respuestas}. El valor recomendado es del 10\% del total de entrevistas objetivo
 de la encuesta. Es mutuamente excluyente con el campo \code{respuestas}.}
-
-\item{\code{opinometro_id}}{Valor entero. Identificador del cuestionario aplicado en campo generado
+      \item{\code{opinometro_id}}{Valor entero. Identificador del cuestionario aplicado en campo generado
 en la plataforma \code{Opinómetro}. Es necesario consultar a la persona que construyó el
 cuestionario para conocer el \code{opinometro_id} asociado. Es mutuamente excluyente con el
 campo \code{respuestas}.}
-
-\item{\code{pool}}{Objeto tipo \link{pool} generado al conectarse a la base de datos que almacena las
-respuestas. Se recomienda utilizar la función \code{\link[=dbPool]{dbPool()}} de la paquetería \link{pool} para esto.}
-
-\item{\code{bd_categorias}}{\code{\link[=tibble]{tibble()}} que contiene los resultados generados por IA a partir de las
+      \item{\code{pool}}{Objeto tipo \link[pool:pool]{pool} generado al conectarse a la base de datos que almacena las
+respuestas. Se recomienda utilizar la función \code{\link[pool:dbPool]{dbPool()}} de la paquetería \link[pool:pool]{pool} para esto.}
+      \item{\code{bd_categorias}}{\code{\link[tibble:tibble]{tibble()}} que contiene los resultados generados por IA a partir de las
 preguntas abiertas.}
-
-\item{\code{bd_correcciones}}{\code{\link[=tibble]{tibble()}} que contiene las correcciones de los registros de las encuestas
+      \item{\code{bd_correcciones}}{\code{\link[tibble:tibble]{tibble()}} que contiene las correcciones de los registros de las encuestas
 efectivas.}
-
-\item{\code{patron}}{Valor tipo caracter que indica qué cadenas de texto quitar de las posibles opciones
+      \item{\code{patron}}{Valor tipo caracter que indica qué cadenas de texto quitar de las posibles opciones
 de respuesta a las preguntas para no presentarlas en los resultados.}
-
-\item{\code{quitar_vars}}{\code{DEPRECATED} Vector tipo caracter que contiene las variables que se desean
+      \item{\code{quitar_vars}}{\code{DEPRECATED} Vector tipo caracter que contiene las variables que se desean
 omitir del procesamiento.}
-
-\item{\code{mantener}}{Vector tipo caracter que indica los clusters a los cuales habrá que forzar las
+      \item{\code{mantener}}{Vector tipo caracter que indica los clusters a los cuales habrá que forzar las
 entrevistas que se hayan levantado cerca de los mismos.}
-
-\item{\code{auditar}}{Vector tipo caracter que contiene las varaibles que se mostraán en la aplicación
+      \item{\code{auditar}}{Vector tipo caracter que contiene las varaibles que se mostraán en la aplicación
 de monitoreo de levantamiento en la pestala \code{Resultados}.}
-
-\item{\code{vars_tendencias}}{Vector tipo caracter que contiene las variables que se mostrarán en la
+      \item{\code{vars_tendencias}}{Vector tipo caracter que contiene las variables que se mostrarán en la
 aplicación de monitoreo de levantamiento en la sección \code{Tendencias}.}
-
-\item{\code{sin_peso}}{\code{LOGICAL} Determina si esl diseno muestral construido será ponderado o no.}
-
-\item{\code{rake}}{\code{LOGICAL} Determina si el diseno muestral será postestratificado por edad y sexo.}
-
-\item{\code{tipo_encuesta}}{\code{DEPRECATED}. La paquetería cuenta con un modo de cálculo de diseño muestral
+      \item{\code{sin_peso}}{\code{LOGICAL} Determina si esl diseno muestral construido será ponderado o no.}
+      \item{\code{rake}}{\code{LOGICAL} Determina si el diseno muestral será postestratificado por edad y sexo.}
+      \item{\code{tipo_encuesta}}{\code{DEPRECATED}. La paquetería cuenta con un modo de cálculo de diseño muestral
 análogo al \code{INEGI}. Sin embargo, este modo ha entrado en desuso y en un futuro desaparecerá.}
-
-\item{\code{respuestas}}{\code{\link[=tibble]{tibble()}} de respuestas obtenidas por las personas entrevistadas.}
-
-\item{\code{auditoria_telefonica}}{\code{\link[=tibble]{tibble()}} que contiene las entrevistas que, por auditoría telefónica,
+      \item{\code{respuestas}}{\code{\link[tibble:tibble]{tibble()}} de respuestas obtenidas por las personas entrevistadas.}
+      \item{\code{auditoria_telefonica}}{\code{\link[tibble:tibble]{tibble()}} que contiene las entrevistas que, por auditoría telefónica,
 han sido eliminadas de los registros.}
-
-\item{\code{mantener_falta_coordenadas}}{\code{LOGICAL}. Determina si se descartan o no las entrevistas sin
+      \item{\code{mantener_falta_coordenadas}}{\code{LOGICAL}. Determina si se descartan o no las entrevistas sin
 geolocalización válida o nula.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Survey_analisis-simular_surveytogo"></a>}}
 \if{latex}{\out{\hypertarget{method-Survey_analisis-simular_surveytogo}{}}}
-\subsection{Method \code{simular_surveytogo()}}{
-Simula una base de respuestas de campo a parti del diccionario delos insumos mínumos necesarios
+\subsection{\code{Survey_analisis$simular_surveytogo()}}{
+  Simula una base de respuestas de campo a parti del diccionario delos insumos mínumos necesarios
 y suficientes.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Survey_analisis$simular_surveytogo(cuestionario, n, diseño, shp)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Survey_analisis$simular_surveytogo(cuestionario, n, diseño, shp)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{cuestionario}}{Campo de la clase encuesta.}
+      \item{\code{n}}{Valor entero. Define el \code{\link[=nrow]{nrow()}} del \code{\link[tibble:tibble]{tibble()}} de respuestas simuladas.}
+      \item{\code{diseño}}{Parámetro inicial de la clase \code{Encuesta}.}
+      \item{\code{shp}}{Parámetro inicial de la clase \code{Encuesta}.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{cuestionario}}{Campo de la clase encuesta.}
-
-\item{\code{n}}{Valor entero. Define el \code{\link[=nrow]{nrow()}} del \code{\link[=tibble]{tibble()}} de respuestas simuladas.}
-
-\item{\code{diseño}}{Parámetro inicial de la clase \code{Encuesta}.}
-
-\item{\code{shp}}{Parámetro inicial de la clase \code{Encuesta}.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Survey_analisis-error_muestral_maximo"></a>}}
 \if{latex}{\out{\hypertarget{method-Survey_analisis-error_muestral_maximo}{}}}
-\subsection{Method \code{error_muestral_maximo()}}{
-Cálculo del error muestral de cada pregunta de opción múltiple y despliegue de resultados
+\subsection{\code{Survey_analisis$error_muestral_maximo()}}{
+  Cálculo del error muestral de cada pregunta de opción múltiple y despliegue de resultados
 en forma de objeto de ggplot2
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Survey_analisis$error_muestral_maximo(quitar_patron = NULL)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Survey_analisis$error_muestral_maximo(quitar_patron = NULL)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{quitar_patron}}{Vector tipo vacater que contiene los patrones coumnes entre nombres
+de variables que se deben omitir en el cálculo.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{quitar_patron}}{Vector tipo vacater que contiene los patrones coumnes entre nombres
-de variables que se deben omitir en el cálculo.}
-}
-\if{html}{\out{</div>}}
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Survey_analisis-exportar_entregable"></a>}}
 \if{latex}{\out{\hypertarget{method-Survey_analisis-exportar_entregable}{}}}
-\subsection{Method \code{exportar_entregable()}}{
-Exportar entregables al terminar cada levantamiento.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Survey_analisis$exportar_entregable(
+\subsection{\code{Survey_analisis$exportar_entregable()}}{
+  Exportar entregables al terminar cada levantamiento.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Survey_analisis$exportar_entregable(
   carpeta = "entregables",
   agregar = NULL,
   quitar = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{carpeta}}{Nombre de la carpeta de destino}
-
-\item{\code{agregar}}{Vector tipo caracter que contiene las variables que se entregan en la base
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{carpeta}}{Nombre de la carpeta de destino}
+      \item{\code{agregar}}{Vector tipo caracter que contiene las variables que se entregan en la base
 de datos.}
-
-\item{\code{quitar}}{Vector tipo caracter que contiene las variables que se omiten en la base
+      \item{\code{quitar}}{Vector tipo caracter que contiene las variables que se omiten en la base
 de datos.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Survey_analisis-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Survey_analisis-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Survey_analisis$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Survey_analisis$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Survey_analisis$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Tendencias.Rd
+++ b/man/Tendencias.Rd
@@ -5,35 +5,36 @@
 \title{Esta es la clase de Tendencias}
 \description{
 Esta es la clase de Tendencias
-
-Esta es la clase de Tendencias
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Tendencias-new}{\code{Tendencias$new()}}
-\item \href{#method-Tendencias-intencion_voto}{\code{Tendencias$intencion_voto()}}
-\item \href{#method-Tendencias-conocimiento}{\code{Tendencias$conocimiento()}}
-\item \href{#method-Tendencias-intencion_voto_region}{\code{Tendencias$intencion_voto_region()}}
-\item \href{#method-Tendencias-conocimiento_region}{\code{Tendencias$conocimiento_region()}}
-\item \href{#method-Tendencias-clone}{\code{Tendencias$clone()}}
-}
+  \itemize{
+    \item \href{#method-Tendencias-initialize}{\code{Tendencias$new()}}
+    \item \href{#method-Tendencias-intencion_voto}{\code{Tendencias$intencion_voto()}}
+    \item \href{#method-Tendencias-conocimiento}{\code{Tendencias$conocimiento()}}
+    \item \href{#method-Tendencias-intencion_voto_region}{\code{Tendencias$intencion_voto_region()}}
+    \item \href{#method-Tendencias-conocimiento_region}{\code{Tendencias$conocimiento_region()}}
+    \item \href{#method-Tendencias-clone}{\code{Tendencias$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Tendencias-new"></a>}}
-\if{latex}{\out{\hypertarget{method-Tendencias-new}{}}}
-\subsection{Method \code{new()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Tendencias$new(encuesta = NULL, diseno = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<a id="method-Tendencias-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-Tendencias-initialize}{}}}
+\subsection{\code{Tendencias$new()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Tendencias$new(encuesta = NULL, diseno = NULL)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Tendencias-intencion_voto"></a>}}
 \if{latex}{\out{\hypertarget{method-Tendencias-intencion_voto}{}}}
-\subsection{Method \code{intencion_voto()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Tendencias$intencion_voto(
+\subsection{\code{Tendencias$intencion_voto()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Tendencias$intencion_voto(
   variable,
   valores_interes,
   colores,
@@ -41,16 +42,18 @@ Esta es la clase de Tendencias
   linea_peso = F,
   size_fech = 8,
   size_text_legend = 12
-)}\if{html}{\out{</div>}}
+)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Tendencias-conocimiento"></a>}}
 \if{latex}{\out{\hypertarget{method-Tendencias-conocimiento}{}}}
-\subsection{Method \code{conocimiento()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Tendencias$conocimiento(
+\subsection{\code{Tendencias$conocimiento()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Tendencias$conocimiento(
   variables,
   colores,
   sin_peso = T,
@@ -58,16 +61,18 @@ Esta es la clase de Tendencias
   linea_peso = F,
   size_fech = 8,
   size_text_legend = 12
-)}\if{html}{\out{</div>}}
+)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Tendencias-intencion_voto_region"></a>}}
 \if{latex}{\out{\hypertarget{method-Tendencias-intencion_voto_region}{}}}
-\subsection{Method \code{intencion_voto_region()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Tendencias$intencion_voto_region(
+\subsection{\code{Tendencias$intencion_voto_region()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Tendencias$intencion_voto_region(
   variable,
   valores_interes,
   colores,
@@ -76,16 +81,18 @@ Esta es la clase de Tendencias
   linea_peso = F,
   size_fech = 8,
   size_text_legend = 12
-)}\if{html}{\out{</div>}}
+)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Tendencias-conocimiento_region"></a>}}
 \if{latex}{\out{\hypertarget{method-Tendencias-conocimiento_region}{}}}
-\subsection{Method \code{conocimiento_region()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Tendencias$conocimiento_region(
+\subsection{\code{Tendencias$conocimiento_region()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Tendencias$conocimiento_region(
   variables,
   colores,
   sin_peso = T,
@@ -94,25 +101,28 @@ Esta es la clase de Tendencias
   linea_peso = F,
   size_fech = 8,
   size_text_legend = 12
-)}\if{html}{\out{</div>}}
+)}
+    \if{html}{\out{</div>}}
+  }
 }
 
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Tendencias-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Tendencias-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Tendencias$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Tendencias$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Tendencias$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/analisis_correspondencia.Rd
+++ b/man/analisis_correspondencia.Rd
@@ -13,9 +13,6 @@ analisis_correspondencia(
   colores = NULL
 )
 }
-\arguments{
-\item{colores}{}
-}
 \description{
 Title
 }

--- a/man/analizar_blackbox_1d.Rd
+++ b/man/analizar_blackbox_1d.Rd
@@ -6,9 +6,6 @@
 \usage{
 analizar_blackbox_1d(bd, vars, stimuli)
 }
-\arguments{
-\item{stimuli}{}
-}
 \description{
 Title
 }

--- a/man/analizar_candidatoPartido.Rd
+++ b/man/analizar_candidatoPartido.Rd
@@ -30,7 +30,7 @@ analizar_candidatoPartido(
 \item{corte_otro}{Parámetro 'prop' de la función 'fct_lump' de la paquetería 'forcats' usado para agrupar valores pequeños de partidos políticos}
 }
 \value{
-Lista de donde cada elemento es un \code{\link[=tibble]{tibble()}} asociado al conocimiento y asociacion partidista
+Lista de donde cada elemento es un \code{\link[tibble:tibble]{tibble()}} asociado al conocimiento y asociacion partidista
 }
 \description{
 Calcula las estimaciones de asociacion partidista de un personaje en particular

--- a/man/analizar_cruce.Rd
+++ b/man/analizar_cruce.Rd
@@ -25,7 +25,7 @@ analizar_cruce(
 \item{na_rm}{na_rm=FALSE Variable booleana que indica si se desea filtrar NAs (TRUE) o no (FALSE)}
 }
 \value{
-\code{\link[=tibble]{tibble()}} con las estimaciones de frecuencia para cada valor unico entre las variables
+\code{\link[tibble:tibble]{tibble()}} con las estimaciones de frecuencia para cada valor unico entre las variables
 }
 \description{
 Analizar cruce entre dos variables

--- a/man/analizar_cruce_aspectos.Rd
+++ b/man/analizar_cruce_aspectos.Rd
@@ -25,7 +25,7 @@ analizar_cruce_aspectos(
 \item{vartype}{Parametro de \code{\link[srvyr:survey_mean]{srvyr::survey_mean()}} que reporta la variabilidad de la estimacion}
 }
 \value{
-\code{\link[=tibble]{tibble()}} con las estimaciones de frecuencia para cada valor unico entre las variables
+\code{\link[tibble:tibble]{tibble()}} con las estimaciones de frecuencia para cada valor unico entre las variables
 }
 \description{
 Analizar cruce entre multiples variables cuyos nombres compartan valores unicos

--- a/man/analizar_frecuencias_multirespuesta.Rd
+++ b/man/analizar_frecuencias_multirespuesta.Rd
@@ -13,7 +13,7 @@ analizar_frecuencias_multirespuesta(diseno, patron_inicial)
 \item{patron_inicial}{Cadena de texto en comun (inicial) entre los nombres de las variables asociadas a la pregunta}
 }
 \value{
-\code{\link[=tibble]{tibble()}} con las estimaciones de frecuencia para cada valor unico entre las variables
+\code{\link[tibble:tibble]{tibble()}} con las estimaciones de frecuencia para cada valor unico entre las variables
 }
 \description{
 Analizar frecuencias a multiples variables asociadas a una misma pregunta con opcion a multirespuesta

--- a/man/analizar_sankey.Rd
+++ b/man/analizar_sankey.Rd
@@ -17,7 +17,7 @@ se va a hacer el cruce}
 \item{filtro_var2}{Valores de interes de la primer variable presente en el vector}
 }
 \value{
-\code{\link[=tibble]{tibble()}} con las estimaciones de frecuencia para cada valor unico entre las variables
+\code{\link[tibble:tibble]{tibble()}} con las estimaciones de frecuencia para cada valor unico entre las variables
 }
 \description{
 Calcular datos necesarios para la funcion \code{\link[=graficar_sankey]{graficar_sankey()}}

--- a/man/asignar_coloresCategorias.Rd
+++ b/man/asignar_coloresCategorias.Rd
@@ -12,9 +12,6 @@ asignar_coloresCategorias(
   colores = c("#6a104d", "#ff8cf2")
 )
 }
-\arguments{
-\item{bd_proporcionesCategorias}{}
-}
 \description{
 Title
 }

--- a/man/aspectos_dicc.Rd
+++ b/man/aspectos_dicc.Rd
@@ -6,9 +6,6 @@
 \usage{
 aspectos_dicc(dicc)
 }
-\arguments{
-\item{dicc}{}
-}
 \description{
 Title
 }

--- a/man/calcular_intentosEfectivos_opinometro.Rd
+++ b/man/calcular_intentosEfectivos_opinometro.Rd
@@ -6,9 +6,6 @@
 \usage{
 calcular_intentosEfectivos_opinometro(bd_respuestasOpinometro)
 }
-\arguments{
-\item{bd_respuestasOpinometro}{}
-}
 \description{
 Title
 }

--- a/man/calcular_mediaMovil.Rd
+++ b/man/calcular_mediaMovil.Rd
@@ -8,7 +8,7 @@ de un diseno muestral construido con la paqueteria \code{survey}}
 calcular_mediaMovil(bd_resultados, variable, valores_interes, sin_peso)
 }
 \arguments{
-\item{bd_resultados}{\code{\link[=tibble]{tibble()}} que contien la variable de interes y los pesos necesarios para el calculo}
+\item{bd_resultados}{\code{\link[tibble:tibble]{tibble()}} que contien la variable de interes y los pesos necesarios para el calculo}
 
 \item{variable}{Nombre de la variable de interes}
 
@@ -17,7 +17,7 @@ calcular_mediaMovil(bd_resultados, variable, valores_interes, sin_peso)
 \item{sin_peso}{Logical. Se usa para calcular resultados con o sin pesos}
 }
 \value{
-\code{\link[=tibble]{tibble()}} con las variables: hora, variable_interes, movil_variable_nteres
+\code{\link[tibble:tibble]{tibble()}} con las variables: hora, variable_interes, movil_variable_nteres
 }
 \description{
 Calcular media movil de una variable

--- a/man/calcular_mediaMovil_region.Rd
+++ b/man/calcular_mediaMovil_region.Rd
@@ -14,7 +14,7 @@ calcular_mediaMovil_region(
 )
 }
 \arguments{
-\item{bd_resultados}{\code{\link[=tibble]{tibble()}} que contien la variable de interes y los pesos necesarios para el calculo}
+\item{bd_resultados}{\code{\link[tibble:tibble]{tibble()}} que contien la variable de interes y los pesos necesarios para el calculo}
 
 \item{variable}{Nombre de la variable de interes}
 
@@ -25,7 +25,7 @@ calcular_mediaMovil_region(
 \item{sin_peso}{Logical. Se usa para calcular resultados con o sin pesos}
 }
 \value{
-\code{\link[=tibble]{tibble()}} con las variables: hora, variable_interes, movil_variable_nteres
+\code{\link[tibble:tibble]{tibble()}} con las variables: hora, variable_interes, movil_variable_nteres
 }
 \description{
 Calcular media movil de una variable agrupado por region

--- a/man/calcular_tabla_candidatoOpinion.Rd
+++ b/man/calcular_tabla_candidatoOpinion.Rd
@@ -36,7 +36,7 @@ calcular_tabla_candidatoOpinion(
 \item{salto_respuestas}{Valor entero usato como parametro en \code{\link[stringr:str_wrap]{stringr::str_wrap()}} aplicado a todos los encabezados de la tabla}
 }
 \value{
-\code{\link[=tibble]{tibble()}} con las variables necesarias para la funcion \code{\link[=formatear_tabla_candidatoOpinion]{formatear_tabla_candidatoOpinion()}}
+\code{\link[tibble:tibble]{tibble()}} con las variables necesarias para la funcion \code{\link[=formatear_tabla_candidatoOpinion]{formatear_tabla_candidatoOpinion()}}
 }
 \description{
 Produce y ordena los resultados necesarios para la funcion \code{\link[=formatear_tabla_candidatoOpinion]{formatear_tabla_candidatoOpinion()}}

--- a/man/calcular_tabla_votoCruzado.Rd
+++ b/man/calcular_tabla_votoCruzado.Rd
@@ -18,7 +18,7 @@ calcular_tabla_votoCruzado(diseno, var1, var2, filtro_var2, na_rm = TRUE)
 \item{na_rm}{na_rm=TRUE Variable booleana que indica si se desea filtrar NAs (TRUE) o no (FALSE)}
 }
 \value{
-\code{\link[=tibble]{tibble()}} con las variables necesarias para la funcion \code{\link[=formatear_tabla_votoCruzado]{formatear_tabla_votoCruzado()}}
+\code{\link[tibble:tibble]{tibble()}} con las variables necesarias para la funcion \code{\link[=formatear_tabla_votoCruzado]{formatear_tabla_votoCruzado()}}
 }
 \description{
 Calcular y ordena los resultados de un cruce entre una variable principal y una variable secundaria.

--- a/man/comprobar_unicidadLlaves.Rd
+++ b/man/comprobar_unicidadLlaves.Rd
@@ -6,9 +6,6 @@
 \usage{
 comprobar_unicidadLlaves(diccionario)
 }
-\arguments{
-\item{diccionario}{}
-}
 \description{
 Title
 }

--- a/man/consultar_respuestas.Rd
+++ b/man/consultar_respuestas.Rd
@@ -6,9 +6,6 @@
 \usage{
 consultar_respuestas(pool, codigos, encuesta_id)
 }
-\arguments{
-\item{encuesta_id}{}
-}
 \description{
 Title
 }

--- a/man/consultar_respuestas_existentes.Rd
+++ b/man/consultar_respuestas_existentes.Rd
@@ -12,7 +12,7 @@ consultar_respuestas_existentes(pool, id_cuestionario)
 \item{id_cuestionario}{Entero. Identificador del cuestionario en Opinómetro.}
 }
 \value{
-Un \code{\link[=tibble]{tibble()}} con una fila por registro y una columna por pregunta.
+Un \code{\link[tibble:tibble]{tibble()}} con una fila por registro y una columna por pregunta.
 }
 \description{
 Obtiene todos los registros del cuestionario indicado desde la

--- a/man/corregir_cluster.Rd
+++ b/man/corregir_cluster.Rd
@@ -6,9 +6,6 @@
 \usage{
 corregir_cluster(respuestas, shp, mantener, nivel, var_n)
 }
-\arguments{
-\item{mantener}{}
-}
 \description{
 Title
 }

--- a/man/determinar_contenidoCuestionario.Rd
+++ b/man/determinar_contenidoCuestionario.Rd
@@ -6,9 +6,6 @@
 \usage{
 determinar_contenidoCuestionario(pool, id_cuestionario)
 }
-\arguments{
-\item{id_cuestionario}{}
-}
 \description{
 Title
 }

--- a/man/diccionario_cuestionario.Rd
+++ b/man/diccionario_cuestionario.Rd
@@ -6,9 +6,6 @@
 \usage{
 diccionario_cuestionario(doc, patron)
 }
-\arguments{
-\item{doc}{}
-}
 \description{
 Title
 }

--- a/man/dist_poligonos.Rd
+++ b/man/dist_poligonos.Rd
@@ -6,9 +6,6 @@
 \usage{
 dist_poligonos(base_sf, shp, var_n, nivel)
 }
-\arguments{
-\item{nivel}{}
-}
 \description{
 Title
 }

--- a/man/dist_puntos.Rd
+++ b/man/dist_puntos.Rd
@@ -6,9 +6,6 @@
 \usage{
 dist_puntos(base_sf, encuesta, muestra, var_n, nivel)
 }
-\arguments{
-\item{nivel}{}
-}
 \description{
 Title
 }

--- a/man/estandarizar_texto.Rd
+++ b/man/estandarizar_texto.Rd
@@ -11,9 +11,6 @@ estandarizar_texto(
   minusculas = TRUE
 )
 }
-\arguments{
-\item{minusculas}{}
-}
 \description{
 Estandarizar texto para imitar resultados de la categorizacion con el bot
 }

--- a/man/exportar_bd.Rd
+++ b/man/exportar_bd.Rd
@@ -6,9 +6,6 @@
 \usage{
 exportar_bd(self, carpeta, agregar, quitar)
 }
-\arguments{
-\item{quitar}{}
-}
 \description{
 Title
 }

--- a/man/formatear_tabla_candidatoOpinion.Rd
+++ b/man/formatear_tabla_candidatoOpinion.Rd
@@ -17,9 +17,6 @@ formatear_tabla_candidatoOpinion(
   color_conocimiento
 )
 }
-\arguments{
-\item{orden_opinion}{}
-}
 \description{
 Title
 }

--- a/man/formatear_tabla_votoCruzado.Rd
+++ b/man/formatear_tabla_votoCruzado.Rd
@@ -17,9 +17,6 @@ formatear_tabla_votoCruzado(
   salto
 )
 }
-\arguments{
-\item{salto}{}
-}
 \description{
 Title
 }

--- a/man/formato_archivo.Rd
+++ b/man/formato_archivo.Rd
@@ -6,9 +6,6 @@
 \usage{
 formato_archivo(nombre, extension, tolerancia = 10)
 }
-\arguments{
-\item{tolerancia}{}
-}
 \description{
 Title
 }

--- a/man/gant_p_r.Rd
+++ b/man/gant_p_r.Rd
@@ -6,9 +6,6 @@
 \usage{
 gant_p_r(dicc)
 }
-\arguments{
-\item{dicc}{}
-}
 \description{
 Title
 }

--- a/man/generarGlosario_preguntaAbierta.Rd
+++ b/man/generarGlosario_preguntaAbierta.Rd
@@ -11,9 +11,6 @@ generarGlosario_preguntaAbierta(
   variable
 )
 }
-\arguments{
-\item{variable}{}
-}
 \description{
 Title
 }

--- a/man/graficar_barras.Rd
+++ b/man/graficar_barras.Rd
@@ -25,10 +25,10 @@ graficar_barras(
 \item{orden_respuestas}{Vector ordenado tipo caracter usado para ordenar los valores del eje x}
 }
 \value{
-Objeto tipo \link{ggplot}
+Objeto tipo \link[ggplot2:ggplot]{ggplot}
 }
 \description{
-Recibe un \code{\link[=tibble]{tibble()}} y genera un objeto tipo \link{ggplot}. El producto es una grafica de barras
+Recibe un \code{\link[tibble:tibble]{tibble()}} y genera un objeto tipo \link[ggplot2:ggplot]{ggplot}. El producto es una grafica de barras
 ordenadas de acuerdo al criterio indicado.
 }
 \examples{

--- a/man/graficar_barras_saldo.Rd
+++ b/man/graficar_barras_saldo.Rd
@@ -22,7 +22,7 @@ graficar_barras_saldo(
 )
 }
 \arguments{
-\item{bd}{\code{\link[=tibble]{tibble()}} que contiene las variables necesarias para generar la grafica}
+\item{bd}{\code{\link[tibble:tibble]{tibble()}} que contiene las variables necesarias para generar la grafica}
 
 \item{orden}{Vector ordenado tipo caracter usado para ordenar los valores del eje x}
 
@@ -40,19 +40,19 @@ graficar_barras_saldo(
 
 \item{caption_opinion}{Cadena de texto usada en el parametro \link{caption} de la funcion \code{\link[ggplot2:labs]{ggplot2::labs()}}}
 
-\item{size_text_cat}{Parametro \link{size} de la funcion \code{\link[ggplot2:element]{ggplot2::element_text()}} usado en el parametro \link{axis.text.x} en el tema particular del grafico}
+\item{size_text_cat}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggplot2:element_text]{ggplot2::element_text()}} usado en el parametro \link{axis.text.x} en el tema particular del grafico}
 
-\item{size_pct}{Parametro \link{size} de la funcion \code{\link[ggfittext:geom_fit_text]{ggfittext::geom_fit_text()}} que controla el tamano del texto que muestra el porcentaje dentro de las barras}
+\item{size_pct}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggfittext:geom_fit_text]{ggfittext::geom_fit_text()}} que controla el tamano del texto que muestra el porcentaje dentro de las barras}
 
-\item{size_caption_opinion}{Parametro \link{size} de la funcion \code{\link[ggplot2:element]{ggplot2::element_text()}} usado en el parametro \link{plot.caption} en el tema particular del grafico}
+\item{size_caption_opinion}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggplot2:element_text]{ggplot2::element_text()}} usado en el parametro \link{plot.caption} en el tema particular del grafico}
 
-\item{tema}{Tema grafico de \link{ggplot2}}
+\item{tema}{Tema grafico de \link[ggplot2:ggplot2]{ggplot2}}
 }
 \value{
-Objeto tipo \link{ggplot}
+Objeto tipo \link[ggplot2:ggplot]{ggplot}
 }
 \description{
-Recibe un \code{\link[=tibble]{tibble()}} y genera un objeto tipo \link{ggplot}. El producto es una grafica tipo barras horizontales
+Recibe un \code{\link[tibble:tibble]{tibble()}} y genera un objeto tipo \link[ggplot2:ggplot]{ggplot}. El producto es una grafica tipo barras horizontales
 diferenciando dos grupos principales: positivos y negativos. Los resultados mostrados omiten la
 categoria de No sabe No contesta
 }

--- a/man/graficar_candidatoPartido.Rd
+++ b/man/graficar_candidatoPartido.Rd
@@ -35,7 +35,7 @@ graficar_candidatoPartido(
 \item{size_text_conocimiento}{Valor de tipo entero. Tamaño de los porcentajes en la grafica de conocimiento.}
 }
 \description{
-Recibe un \code{\link[=tibble]{tibble()}} y genera un objeto tipo \link{ggplot}. El producto es una grafica tipo barras horizontales
+Recibe un \code{\link[tibble:tibble]{tibble()}} y genera un objeto tipo \link[ggplot2:ggplot]{ggplot}. El producto es una grafica tipo barras horizontales
 combinada con una grafica tipo intervalos. La grafica tipo barras muestra los porcentajes con de
 con los que asocian a determinado personaje. La grafica de intervalos muestra el nivel de conocimiento
 del mismo.

--- a/man/graficar_candidatoSaldo.Rd
+++ b/man/graficar_candidatoSaldo.Rd
@@ -24,7 +24,7 @@ graficar_candidatoSaldo(
 \item{color_negativo}{Color asociado al grupo negativo.}
 }
 \value{
-Objeto tipo \link{ggplot}
+Objeto tipo \link[ggplot2:ggplot]{ggplot}
 }
 \description{
 Graficar saldo de opinión por personaje

--- a/man/graficar_candidato_opinion.Rd
+++ b/man/graficar_candidato_opinion.Rd
@@ -46,7 +46,7 @@ graficar_candidato_opinion(
 
 \item{colores}{Vector ordenado de colores asociados al grupo negativo, regular y positivo.}
 
-\item{color_nsnc}{Color para usar en parametro \link{fill} en el grafico de barras asociado a la cateogira No sabe o No contesta}
+\item{color_nsnc}{Color para usar en parametro \link[tidyr:fill]{fill} en el grafico de barras asociado a la cateogira No sabe o No contesta}
 
 \item{burbuja}{Base de datos con estructura producida por analizar_frecuencias_aspectos filtrada por un valor de interés. Disponible en el enviroment.}
 
@@ -68,7 +68,7 @@ graficar_candidato_opinion(
 
 \item{size_text_cat}{Tamaño del texto de las categorías diferentes categorías de la variable 'tema' de la base de datos 'bd'}
 
-\item{size_pct}{Parametro \link{size} de la funcion \code{\link[ggfittext:geom_fit_text]{ggfittext::geom_fit_text()}} que controla el tamano del texto que muestra el porcentaje dentro de las barras}
+\item{size_pct}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggfittext:geom_fit_text]{ggfittext::geom_fit_text()}} que controla el tamano del texto que muestra el porcentaje dentro de las barras}
 
 \item{orden_resp}{Vector ordenado de los posibles valores de la variable 'respuesta'}
 
@@ -85,10 +85,10 @@ graficar_candidato_opinion(
 \item{patron_inicial}{PENDIENTE}
 }
 \value{
-Objeto tipo \link{ggplot} compuesto por la union de al menos dos
+Objeto tipo \link[ggplot2:ggplot]{ggplot} compuesto por la union de al menos dos
 }
 \description{
-Recibe un \code{\link[=tibble]{tibble()}} y genera un objeto tipo \link{ggplot}. El producto es una grafica tipo barras horizontales
+Recibe un \code{\link[tibble:tibble]{tibble()}} y genera un objeto tipo \link[ggplot2:ggplot]{ggplot}. El producto es una grafica tipo barras horizontales
 con el grafico tipo burbuja y el grafico tipo  barras para los porcentajes de No sabe No contesta
 }
 \examples{

--- a/man/graficar_cruce_bloques.Rd
+++ b/man/graficar_cruce_bloques.Rd
@@ -25,15 +25,15 @@ graficar_cruce_bloques(
 
 \item{vartype}{Parametro de \code{\link[srvyr:survey_mean]{srvyr::survey_mean()}} que reporta la variabilidad de la estimacion}
 
-\item{linea_grosor}{Parametro \link{size} de la funcion \code{\link[treemapify:geom_treemap_subgroup_border]{treemapify::geom_treemap_subgroup_border()}} que modifica el grosor de las lineas que dividen los subgrupos de un bloque}
+\item{linea_grosor}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[treemapify:geom_treemap_subgroup_border]{treemapify::geom_treemap_subgroup_border()}} que modifica el grosor de las lineas que dividen los subgrupos de un bloque}
 
-\item{linea_color}{Parametro \link{color} de la funcion \code{\link[treemapify:geom_treemap_subgroup_border]{treemapify::geom_treemap_subgroup_border()}} que modifica el color de las lineas que dividen los subgrupos de un bloque}
+\item{linea_color}{Parametro \link[ggplot2:color]{color} de la funcion \code{\link[treemapify:geom_treemap_subgroup_border]{treemapify::geom_treemap_subgroup_border()}} que modifica el color de las lineas que dividen los subgrupos de un bloque}
 }
 \value{
-Objeto tipo \link{ggplot}
+Objeto tipo \link[ggplot2:ggplot]{ggplot}
 }
 \description{
-Recibe un \code{\link[=tibble]{tibble()}} y genera un objeto tipo \link{ggplot}. El producto es una grafica bloques usando
+Recibe un \code{\link[tibble:tibble]{tibble()}} y genera un objeto tipo \link[ggplot2:ggplot]{ggplot}. El producto es una grafica bloques usando
 \code{\link[treemapify:geom_treemap]{treemapify::geom_treemap()}}. Este tipo de grafico es util para cruces cuya variable principal
 es de pocos valores como el sexo.
 }

--- a/man/graficar_gauge.Rd
+++ b/man/graficar_gauge.Rd
@@ -24,10 +24,10 @@ graficar_gauge(
 \item{size_text_pct}{Tamaño del texto dentro del gauge}
 }
 \value{
-Objeto tipo \link{ggplot}
+Objeto tipo \link[ggplot2:ggplot]{ggplot}
 }
 \description{
-Recibe un \code{\link[=tibble]{tibble()}} y genera un objeto tipo \link{ggplot}. El producto es una grafica de gauge (donita)
+Recibe un \code{\link[tibble:tibble]{tibble()}} y genera un objeto tipo \link[ggplot2:ggplot]{ggplot}. El producto es una grafica de gauge (donita)
 que se rellena acuerdo al valor contenido en la escala indicada
 }
 \examples{

--- a/man/graficar_heatmap.Rd
+++ b/man/graficar_heatmap.Rd
@@ -32,17 +32,17 @@ graficar_heatmap(
 
 \item{salto_y}{Valor entero usato como parametro en \code{\link[stringr:str_wrap]{stringr::str_wrap()}} aplicado a las filas del eje y}
 
-\item{size_text_x}{Parametro \link{size} de la funcion \code{\link[ggplot2:element]{ggplot2::element_text()}} usado en el parametro \link{axis.text.x} en el tema particular del grafico}
+\item{size_text_x}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggplot2:element_text]{ggplot2::element_text()}} usado en el parametro \link{axis.text.x} en el tema particular del grafico}
 
-\item{size_text_y}{Parametro \link{size} de la funcion \code{\link[ggplot2:element]{ggplot2::element_text()}} usado en el parametro \link{axis.text.y} en el tema particular del grafico}
+\item{size_text_y}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggplot2:element_text]{ggplot2::element_text()}} usado en el parametro \link{axis.text.y} en el tema particular del grafico}
 
-\item{size_text_caption}{Parametro \link{size} de la funcion \code{\link[ggplot2:element]{ggplot2::element_text()}} usado en el parametro \link{plot.caption} en el tema particular del grafico}
+\item{size_text_caption}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggplot2:element_text]{ggplot2::element_text()}} usado en el parametro \link{plot.caption} en el tema particular del grafico}
 }
 \value{
-Objeto tipo \link{ggplot}
+Objeto tipo \link[ggplot2:ggplot]{ggplot}
 }
 \description{
-Recibe un \code{\link[=tibble]{tibble()}} y genera un objeto tipo \link{ggplot}. El producto es una grafica tipo heatmap de
+Recibe un \code{\link[tibble:tibble]{tibble()}} y genera un objeto tipo \link[ggplot2:ggplot]{ggplot}. El producto es una grafica tipo heatmap de
 \code{\link[ggplot2:geom_tile]{ggplot2::geom_tile()}}
 }
 \examples{

--- a/man/graficar_intervalo_numerica.Rd
+++ b/man/graficar_intervalo_numerica.Rd
@@ -21,10 +21,10 @@ graficar_intervalo_numerica(
 \item{text_point_size}{Tamaño del texto que acompaña el valor de la estimación}
 }
 \value{
-Objeto tipo \link{ggplot}
+Objeto tipo \link[ggplot2:ggplot]{ggplot}
 }
 \description{
-Recibe un \code{\link[=tibble]{tibble()}} y genera un objeto tipo \link{ggplot}. El producto es una grafica de puntos \code{\link[ggplot2:geom_point]{ggplot2::geom_point()}}
+Recibe un \code{\link[tibble:tibble]{tibble()}} y genera un objeto tipo \link[ggplot2:ggplot]{ggplot}. El producto es una grafica de puntos \code{\link[ggplot2:geom_point]{ggplot2::geom_point()}}
 con intervalos asociados a los intervalos de confianza
 }
 \examples{

--- a/man/graficar_lineas.Rd
+++ b/man/graficar_lineas.Rd
@@ -30,13 +30,13 @@ graficar_lineas(
 
 \item{text_nudge_y}{Parametro \link{nudge_y} de la funcion \code{\link[ggrepel:geom_text_repel]{ggrepel::geom_text_repel()}} que modifica la posicion del texto en el grafico}
 
-\item{size_text}{Parametro \link{size} de la funcion \code{\link[ggplot2:element]{ggplot2::element_text()}} usado en el parametro \link{axis.text.x} en el tema particular del grafico}
+\item{size_text}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggplot2:element_text]{ggplot2::element_text()}} usado en el parametro \link{axis.text.x} en el tema particular del grafico}
 }
 \value{
-Objeto tipo \link{ggplot}
+Objeto tipo \link[ggplot2:ggplot]{ggplot}
 }
 \description{
-Recibe un \code{\link[=tibble]{tibble()}} y genera un objeto tipo \link{ggplot}. El producto es una grafica de lineas.
+Recibe un \code{\link[tibble:tibble]{tibble()}} y genera un objeto tipo \link[ggplot2:ggplot]{ggplot}. El producto es una grafica de lineas.
 }
 \examples{
 encuestar:::analizar_cruce(diseno = encuesta_demo$muestra$diseno, variable_principal = "region", variable_secundaria = "voto_pr_24", vartype = "cv") |> na.omit() |> dplyr::rename(var_x = region, var_y = voto_pr_24, media = coef) |> encuestar:::graficar_lineas(orden_var_x = c("Perdidas", "Competitivas", "Voto Blando", "Voto Duro"), colores_var_y = c("Claudia Sheinbaum por MORENA-PT-Partido Verde" = "#A6032F", "Xóchitl Gálvez por PAN-PRI-PRD" = "#0339a6", "No recuerda" = "gray40","No contesta" = "gray60", "Jorge Álvarez Máynez por Movimiento Ciudadano" = "#F27405", "Anulé mi voto" = "black"), limits = c(0, 0.5))

--- a/man/graficar_lolipop_diferencias.Rd
+++ b/man/graficar_lolipop_diferencias.Rd
@@ -28,7 +28,7 @@ graficar_lolipop_diferencias(
 
 \item{nudge_x}{Parametro \link{nudge_y} de la funcion \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}} que modifica la posicion del texto en el grafico}
 
-\item{size_geom_text}{Parametro \link{size} de la funcion \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}} que modifica la posicion del texto en el grafico}
+\item{size_geom_text}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggplot2:geom_text]{ggplot2::geom_text()}} que modifica la posicion del texto en el grafico}
 
 \item{caption}{Cadena de texto usada en el parametro \link{caption} de la funcion \code{\link[ggplot2:labs]{ggplot2::labs()}}}
 
@@ -45,10 +45,10 @@ graficar_lolipop_diferencias(
 \item{ajuste_pos}{Valor de tipo decimal. Es el factor de ajuste de posición que los porcentajes graficados tomarán en caso de traslaparse. El porcentaje menor se despalzará la izquierda, y el mayor a la derecha. Solo se efectua si \link{traslape} es TRUE. Por defecto su valor es 0.02.}
 }
 \value{
-Objeto tipo \link{ggplot}
+Objeto tipo \link[ggplot2:ggplot]{ggplot}
 }
 \description{
-Recibe un \code{\link[=tibble]{tibble()}} y genera un objeto tipo \link{ggplot}. El producto es una grafica tipo lolipo
+Recibe un \code{\link[tibble:tibble]{tibble()}} y genera un objeto tipo \link[ggplot2:ggplot]{ggplot}. El producto es una grafica tipo lolipo
 que resalta las diferencias entre dos categorias
 }
 \examples{

--- a/man/graficar_lollipops.Rd
+++ b/man/graficar_lollipops.Rd
@@ -14,23 +14,23 @@ graficar_lollipops(
 )
 }
 \arguments{
-\item{bd}{\code{\link[=tibble]{tibble()}} que contiene las variables necesarias para}
+\item{bd}{\code{\link[tibble:tibble]{tibble()}} que contiene las variables necesarias para}
 
 \item{orden}{Vector ordenado tipo caracter que define el orden de las categorias en el eje x}
 
-\item{limits}{Vector numerico de longitud dos que indica los limites en escala porcentual natural del eje y usando el parametro \link{limits} de la funcion \code{\link[ggplot2:scale_continuous]{ggplot2::scale_y_continuous()}}}
+\item{limits}{Vector numerico de longitud dos que indica los limites en escala porcentual natural del eje y usando el parametro \link[ggplot2:limits]{limits} de la funcion \code{\link[ggplot2:scale_y_continuous]{ggplot2::scale_y_continuous()}}}
 
 \item{width_cats}{Valor entero usato como parametro en \code{\link[stringr:str_wrap]{stringr::str_wrap()}} aplicado a las filas del eje x}
 
-\item{size}{Parametro \link{size} de la funcion \code{\link[ggfittext:geom_segment]{ggfittext::geom_segment()}} y \code{\link[ggfittext:geom_point]{ggfittext::geom_point()}} que controla el tamano del texto que define el tamaño de la linea y el punto de la grafica}
+\item{size}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggfittext:geom_segment]{ggfittext::geom_segment()}} y \code{\link[ggfittext:geom_point]{ggfittext::geom_point()}} que controla el tamano del texto que define el tamaño de la linea y el punto de la grafica}
 
-\item{size_pct}{Parametro \link{size} de la funcion \code{\link[ggfittext:geom_text]{ggfittext::geom_text()}} que controla el tamano del texto que muestra el porcentaje fuera de las lolipos}
+\item{size_pct}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggfittext:geom_text]{ggfittext::geom_text()}} que controla el tamano del texto que muestra el porcentaje fuera de las lolipos}
 }
 \value{
-Objeto tipo \link{ggplot}
+Objeto tipo \link[ggplot2:ggplot]{ggplot}
 }
 \description{
-Recibe un \code{\link[=tibble]{tibble()}} y genera un objeto tipo \link{ggplot}. El producto es una grafica de barras
+Recibe un \code{\link[tibble:tibble]{tibble()}} y genera un objeto tipo \link[ggplot2:ggplot]{ggplot}. El producto es una grafica de barras
 ordenadas de acuerdo al criterio indicado.
 }
 \examples{

--- a/man/graficar_sankey.Rd
+++ b/man/graficar_sankey.Rd
@@ -13,7 +13,7 @@ graficar_sankey(bd, variables, colores, size_text_cat, width_text = 15)
 
 \item{colores}{Argumento usado por scale_fill_manual y sclae_color_manual}
 
-\item{size_text_cat}{Parametro \link{size} de la funcion \code{\link[ggsankey:geom_sankey_label]{ggsankey::geom_sankey_text()}} que determina
+\item{size_text_cat}{Parametro \link[ggplot2:size]{size} de la funcion \code{\link[ggsankey:geom_sankey_text]{ggsankey::geom_sankey_text()}} que determina
 el tamano del texto de las etiquetas en cada nodo del gráfico}
 
 \item{width_text}{Salto de linea que se aplica a las categorias mostradas}

--- a/man/match_dicc_base.Rd
+++ b/man/match_dicc_base.Rd
@@ -6,9 +6,6 @@
 \usage{
 match_dicc_base(self)
 }
-\arguments{
-\item{encuesta_qro}{}
-}
 \description{
 Title
 }

--- a/man/rainfall_p.Rd
+++ b/man/rainfall_p.Rd
@@ -6,9 +6,6 @@
 \usage{
 rainfall_p(dicc)
 }
-\arguments{
-\item{dicc}{}
-}
 \description{
 Title
 }

--- a/man/rectificar_respuestasOpinometro.Rd
+++ b/man/rectificar_respuestasOpinometro.Rd
@@ -11,9 +11,6 @@ rectificar_respuestasOpinometro(
   elim_na_ub = T
 )
 }
-\arguments{
-\item{variables_cuestionario}{}
-}
 \description{
 rectificar_respuestasOpinometro
 }

--- a/man/resumen_cuestionario.Rd
+++ b/man/resumen_cuestionario.Rd
@@ -6,9 +6,6 @@
 \usage{
 resumen_cuestionario(dicc)
 }
-\arguments{
-\item{dicc}{}
-}
 \value{
 \item{a}{Grafica de cascada para saber cuantas preguntas por bloque hay y en total.}
 \item{b}{Grafica indicando cuales son las etiquetas y cuantos aspectos hay para cada pregunta de aspectos.}

--- a/man/tema_morant.Rd
+++ b/man/tema_morant.Rd
@@ -10,10 +10,10 @@ tema_morant(base_family = "Poppins")
 \item{base_family}{Parametro de \code{\link[ggthemes:theme_foundation]{ggthemes::theme_foundation()}} usado como fuente tipografica}
 }
 \value{
-Tema de \link{ggplot2}
+Tema de \link[ggplot2:ggplot2]{ggplot2}
 }
 \description{
-Tema de \link{ggplot2} que contiene el formato de entregables para objetos \link{ggplot2}
+Tema de \link[ggplot2:ggplot2]{ggplot2} que contiene el formato de entregables para objetos \link[ggplot2:ggplot2]{ggplot2}
 }
 \examples{
 encuesta_demo$muestra$diseno$variables |> dplyr::count(voto_pr_24) |> na.omit() |>  ggplot2::ggplot(ggplot2::aes(x = reorder(voto_pr_24, n), y = n, fill = voto_pr_24)) + ggplot2::geom_col() + ggplot2::coord_flip()

--- a/man/tema_transparente.Rd
+++ b/man/tema_transparente.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/graficar.R
 \name{tema_transparente}
 \alias{tema_transparente}
-\title{Tema transparente para usarse en objetos tipo \link{ggplot} que vayan a ser exportados}
+\title{Tema transparente para usarse en objetos tipo \link[ggplot2:ggplot]{ggplot} que vayan a ser exportados}
 \usage{
 tema_transparente()
 }
 \value{
-Tema de \link{ggplot2} que agrega transparencia a los siguientes elementos del grafico:
+Tema de \link[ggplot2:ggplot2]{ggplot2} que agrega transparencia a los siguientes elementos del grafico:
 legend.backgroud, panel.background, plot.background, strip.background
 }
 \description{

--- a/man/var_clave_diccionario.Rd
+++ b/man/var_clave_diccionario.Rd
@@ -6,9 +6,6 @@
 \usage{
 var_clave_diccionario(self, diseno)
 }
-\arguments{
-\item{self}{}
-}
 \description{
 Title
 }

--- a/tests/testthat/helper-muestra.R
+++ b/tests/testthat/helper-muestra.R
@@ -1,0 +1,11 @@
+# Subclase de Muestra para pruebas: evita el constructor pesado
+# (recalcular_fpc sobre el objeto muestra completo) y permite ejercer
+# extraer_diseno() directamente con insumos sintéticos.
+# Mismo patrón que PreprocesoPrueba (helper-preproceso.R).
+MuestraPrueba <- R6::R6Class(
+  classname = "MuestraPrueba",
+  inherit = encuestar:::Muestra,
+  public = list(
+    initialize = function() invisible(self)
+  )
+)

--- a/tests/testthat/test-extraer-diseno-fallback.R
+++ b/tests/testthat/test-extraer-diseno-fallback.R
@@ -5,14 +5,7 @@
 # sección/manzana. Debe ser un ERROR informativo, no un message; el
 # analista puede optar conscientemente con permitir_sin_conglomerados.
 
-# Subclase que evita el constructor pesado (mismo patrón que PreprocesoPrueba)
-MuestraPrueba <- R6::R6Class(
-  classname = "MuestraPrueba",
-  inherit = encuestar:::Muestra,
-  public = list(
-    initialize = function() invisible(self)
-  )
-)
+# MuestraPrueba (subclase sin constructor pesado) vive en helper-muestra.R
 
 respuestas_validas <- function() {
   set.seed(1)

--- a/tests/testthat/test-extraer-diseno-fallback.R
+++ b/tests/testthat/test-extraer-diseno-fallback.R
@@ -1,0 +1,73 @@
+# El fallback silencioso de extraer_diseno() a un diseño SIN conglomerados
+# (ids = ~1) subestima los errores estándar (~25% medido en Chihuahua
+# Ene-2026: EE de 1.34pp con conglomerados vs 1.01pp sin ellos, con más n)
+# porque ignora la correlación intraclase de las entrevistas de una misma
+# sección/manzana. Debe ser un ERROR informativo, no un message; el
+# analista puede optar conscientemente con permitir_sin_conglomerados.
+
+# Subclase que evita el constructor pesado (mismo patrón que PreprocesoPrueba)
+MuestraPrueba <- R6::R6Class(
+  classname = "MuestraPrueba",
+  inherit = encuestar:::Muestra,
+  public = list(
+    initialize = function() invisible(self)
+  )
+)
+
+respuestas_validas <- function() {
+  set.seed(1)
+  tibble::tibble(
+    strata_1 = rep(c("a", "b"), each = 10),
+    cluster_1 = rep(1:4, each = 5),
+    cluster_0 = 1:20,
+    fpc_1 = rep(c(0.5, 0.5, 0.4, 0.4), each = 5),
+    fpc_0 = 0.25,
+    y = rnorm(20)
+  )
+}
+
+test_that("con insumos válidos construye el diseño CON conglomerados", {
+  m <- MuestraPrueba$new()
+  expect_no_error(
+    m$extraer_diseno(
+      respuestas = respuestas_validas(), marco_muestral = NULL,
+      tipo_encuesta = "ine", sin_peso = FALSE, rake = FALSE
+    )
+  )
+  # la UPM quedó declarada (no ids = ~1)
+  expect_gt(ncol(m$diseno$cluster), 0)
+  expect_lt(length(unique(m$diseno$cluster[[1]])), nrow(respuestas_validas()))
+})
+
+test_that("si el diseño con conglomerados falla, es ERROR (no fallback silencioso)", {
+  respuestas_rotas <- respuestas_validas()
+  respuestas_rotas$fpc_1[1:5] <- NA # el modo de fallo real: joins vacíos -> NA en fpc
+
+  m <- MuestraPrueba$new()
+  expect_error(
+    m$extraer_diseno(
+      respuestas = respuestas_rotas, marco_muestral = NULL,
+      tipo_encuesta = "ine", sin_peso = FALSE, rake = FALSE
+    ),
+    regexp = "conglomerados"
+  )
+})
+
+test_that("permitir_sin_conglomerados = TRUE es opt-in consciente con warning", {
+  respuestas_rotas <- respuestas_validas()
+  respuestas_rotas$fpc_1[1:5] <- NA
+
+  m <- MuestraPrueba$new()
+  # svydesign también emite su propio warning informativo al degradar;
+  # se capturan todos y se verifica el nuestro
+  warns <- testthat::capture_warnings(
+    m$extraer_diseno(
+      respuestas = respuestas_rotas, marco_muestral = NULL,
+      tipo_encuesta = "ine", sin_peso = FALSE, rake = FALSE,
+      permitir_sin_conglomerados = TRUE
+    )
+  )
+  expect_true(any(grepl("subestimados", warns)))
+  # el diseño degradado existe (estratificado, sin conglomerados)
+  expect_s3_class(m$diseno, "survey.design")
+})

--- a/tests/testthat/test-monitor-rake.R
+++ b/tests/testthat/test-monitor-rake.R
@@ -1,0 +1,73 @@
+# Monitoreo de los factores de ajuste del rake.
+#
+# Al retirar las cuotas de campo (generan sesgo al intentar cumplirlas),
+# el rake absorbe TODA la corrección de composición demográfica. El costo
+# es varianza: si el campo se desbalancea (p. ej. levantar de día deja
+# fuera a hombres jóvenes), los factores de rake crecen y el deff sube.
+# extraer_diseno() debe reportar el rango de factores y ALERTAR cuando
+# salen del umbral — la señal operativa de que faltan pases de horario.
+
+marco_fixture <- function() {
+  # márgenes poblacionales 50/50 sexo y 50/50 rango de edad
+  tibble::tibble(
+    LN22_18A24_F = 250, LN22_18A24_M = 250,
+    LN22_60YMAS_F = 250, LN22_60YMAS_M = 250
+  )
+}
+
+respuestas_rake <- function(prop_f) {
+  set.seed(10)
+  n <- 400
+  n_f <- round(n * prop_f)
+  tibble::tibble(
+    strata_1 = rep(c("a", "b"), each = n / 2),
+    cluster_1 = rep(1:8, each = n / 8),
+    cluster_0 = 1:n,
+    fpc_1 = rep(rep(c(0.5, 0.4), each = n / 4), 2)[1:n],
+    fpc_0 = 0.25,
+    sexo = c(rep("F", n_f), rep("M", n - n_f)),
+    rango_edad = rep(c("18A24", "60YMAS"), length.out = n)
+  )
+}
+
+test_that("con campo balanceado reporta factores sin alertar", {
+  m <- MuestraPrueba$new()
+  expect_message(
+    expect_no_warning(
+      m$extraer_diseno(
+        respuestas = respuestas_rake(prop_f = 0.5),
+        marco_muestral = marco_fixture(),
+        tipo_encuesta = "ine", sin_peso = FALSE, rake = TRUE
+      )
+    ),
+    regexp = "[Ff]actores"
+  )
+  expect_s3_class(m$diseno, "survey.design")
+})
+
+test_that("con campo muy desbalanceado ALERTA factores de rake extremos", {
+  m <- MuestraPrueba$new()
+  # 85% mujeres contra un margen poblacional de 50%: el factor de los
+  # hombres se dispara por encima del umbral superior
+  expect_warning(
+    m$extraer_diseno(
+      respuestas = respuestas_rake(prop_f = 0.85),
+      marco_muestral = marco_fixture(),
+      tipo_encuesta = "ine", sin_peso = FALSE, rake = TRUE
+    ),
+    regexp = "rake|composición"
+  )
+})
+
+test_that("el umbral de alerta es configurable", {
+  m <- MuestraPrueba$new()
+  # con umbral laxo el mismo desbalance no alerta
+  expect_no_warning(
+    m$extraer_diseno(
+      respuestas = respuestas_rake(prop_f = 0.85),
+      marco_muestral = marco_fixture(),
+      tipo_encuesta = "ine", sin_peso = FALSE, rake = TRUE,
+      umbral_rake = c(0.1, 10)
+    )
+  )
+})

--- a/tests/testthat/test-monitor-rake.R
+++ b/tests/testthat/test-monitor-rake.R
@@ -71,3 +71,26 @@ test_that("el umbral de alerta es configurable", {
     )
   )
 })
+
+test_that("margen poblacional degenerado (0/NA) no produce error críptico", {
+  # si una categoría del margen viene en 0 (columna del marco toda NA:
+  # sum(na.rm=TRUE) da 0), rake fuerza esos pesos a 0, la mediana de los
+  # factores puede ser 0 y la normalización produciría NaN/Inf y un
+  # "missing value where TRUE/FALSE needed". Debe ser un warning claro.
+  m <- MuestraPrueba$new()
+  marco_degenerado <- marco_fixture()
+  marco_degenerado$LN22_18A24_F <- 0
+  marco_degenerado$LN22_18A24_M <- 0
+
+  # sin la validación previa, survey::rake moriría con el error críptico
+  # "Strata in sample absent from population. This Can't Happen"; ahora
+  # debe ser un error accionable que nombra el margen y las categorías
+  expect_error(
+    m$extraer_diseno(
+      respuestas = respuestas_rake(prop_f = 0.5),
+      marco_muestral = marco_degenerado,
+      tipo_encuesta = "ine", sin_peso = FALSE, rake = TRUE
+    ),
+    regexp = "margen poblacional.*rango_edad.*18A24"
+  )
+})


### PR DESCRIPTION
## Qué corrige

1. **Fallback silencioso a diseño sin conglomerados → error explícito.** El fallback dejaba EE ~25% subestimados (medido en Chihuahua Ene-2026, que operó así en producción). Degradar ahora exige `permitir_sin_conglomerados = TRUE` con warning.
2. **Monitor de factores de rake** al retirar las cuotas de campo: reporta min/mediana/max (composición) y alerta fuera de `umbral_rake = c(0.5, 2)`.
3. Tests TDD para ambos (MuestraPrueba en helper compartido).

Contexto completo: `Chihuahua_Ene_2026/informe_metodologico.html` (sección 5) y `doubly robust estimator/docs/DECISION_ARQUITECTURA_PESOS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)