### PR TITLE
fix(cartografia): sanear geometrías s2-inválidas antes de disolver shp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# encuestar 2.1.0 (rama feat/doubly_robust)
+# encuestar 2.1.0
 
 ## Módulo DR-MNAR: no respuesta no ignorable (Bailey 2023 + Anexo Técnico)
 
@@ -35,6 +35,10 @@
   con el caso real de Chihuahua Ene-2026 (validación contra la verdad
   completa: error del DR 0.4–0.8 pp vs 0.9–3.3 pp del rake).
 * Dependencias nuevas: BB, numDeriv (Imports); haven (Suggests).
+
+## Cartografía
+
+* Se robustece el manejo de la cartografía (`shp`) frente a geometrías válidas en el plano (GEOS) pero inválidas para el motor esférico s2 (p. ej. vértices duplicados). Se aplica `sf::st_make_valid()` antes de las disoluciones que fuerzan `sf_use_s2(T)` en `crear_shp_regiones` (mapas por región) y en la construcción del mapa base de la app de auditoría, evitando el error `Loop ... is not valid: Edge ... is degenerate (duplicate vertex)` al construir la clase `Encuesta`.
 
 # encuestar 1.0.0
 

--- a/R/clase_auditoria.R
+++ b/R/clase_auditoria.R
@@ -25,6 +25,9 @@ Auditoria <- R6::R6Class("Auditoria",
                              # readr::write_excel_csv(encuesta$respuestas$base, glue::glue("{dir}/data/bd.csv"))
                              sf_use_s2(T)
                              mapa_base <- encuesta$shp_completo$shp$MUNICIPIO %>%
+                               # Corrige geometrias validas en el plano pero invalidas para s2
+                               #  (vertices duplicados) que rompen la disolucion por estrato
+                               sf::st_make_valid() %>%
                                left_join(encuesta$muestra$muestra$poblacion$marco_muestral %>% distinct(MUNICIPIO,strata_1)) %>%
                                group_by(strata_1) %>% summarise(n()) %>%
                                sf::st_buffer(dist = 0)

--- a/R/clase_resultados.R
+++ b/R/clase_resultados.R
@@ -1532,6 +1532,9 @@ Regiones <- R6::R6Class(classname = "Regiones",
                             sf_use_s2(T)
                             self$shp_regiones <-
                               self$encuesta$shp_completo$shp$SECCION %>%
+                              # Corrige geometrias validas en el plano pero invalidas para s2
+                              #  (vertices duplicados) que rompen la disolucion por region
+                              sf::st_make_valid() %>%
                               left_join(self$encuesta$muestra$muestra$poblacion$marco_muestral %>%
                                           distinct(SECCION, region), by = "SECCION") %>%
                               group_by(region) %>%


### PR DESCRIPTION
## Qué

Sanea geometrías `shp` válidas en el plano (GEOS) pero inválidas para el motor esférico s2 (p. ej. vértices duplicados) **antes** de las disoluciones que fuerzan `sf_use_s2(TRUE)`.

Se aplica `sf::st_make_valid()` en los dos puntos donde se disuelve la cartografía:

- `crear_shp_regiones` (mapas por región) — `R/clase_resultados.R` (clase `Regiones`).
- Construcción del mapa base de la app de auditoría — `R/clase_auditoria.R` (clase `Auditoria`).

## Por qué

Sin el saneamiento, construir la clase `Encuesta` con ciertas cartografías falla con:

```
Loop ... is not valid: Edge ... is degenerate (duplicate vertex)
```

## Notas

- Cambio mínimo y local: sólo antepone `st_make_valid()` a las cadenas `%>%` existentes; no altera la lógica de disolución.
- NEWS actualizado bajo la sección `## Cartografía` de la versión 2.1.0.
