### PR TITLE
fix(preproceso): no tirar variables de cuestionario con subcadena "int"

### DIFF
--- a/R/clase_preprocesamiento.R
+++ b/R/clase_preprocesamiento.R
@@ -197,19 +197,26 @@ Preproceso <-
           }
 
         # Detalle por intento (INT_1..INT_15): cada renglón acumula el
-        # resultado de cada toque de puerta. `-contains("INT")` de abajo los
-        # descarta (junto con gps/aux/etc.), así que se re-adjuntan desde el
-        # crudo para que lleguen al snapshot. Son el insumo de
+        # resultado de cada toque de puerta. El `-matches("^INT_?[0-9]+$")` de
+        # abajo los descarta (junto con gps/aux/etc.), así que se re-adjuntan
+        # desde el crudo para que lleguen al snapshot. Son el insumo de
         # `pivotar_intentos()` / `derivar_registro_contactos()` (registro de
         # contactos y tasa de respuesta por sección para la sobremuestra), que
-        # esperan leerlos DEL snapshot. `matches("^INT[0-9]+$")` toma solo las
-        # numeradas: no arrastra columnas de cuestionario tipo `internet`.
+        # esperan leerlos DEL snapshot.
+        #
+        # IMPORTANTE: el drop de las numeradas DEBE ser un `matches()` anclado,
+        # NO `contains("INT")`. `tidyselect::contains()` hace coincidencia por
+        # subcadena e `ignore.case = TRUE` por defecto, así que `"INT"` también
+        # tiraba variables de cuestionario que contienen las letras "int"
+        # (`internet`, `conoce_interurbano`, `op_interurbano`); al no re-
+        # adjuntarse quedaban 100% NULL en el snapshot.
         cols_intento <- self$bd_respuestas |>
-          select(Id, matches("^INT[0-9]+$"))
+          select(Id, matches("^INT_?[0-9]+$"))
 
         self$bd_respuestas_preparadas <- self$bd_respuestas |>
           select(
-            -contains(c("gps", "intentos_", "introduccion", "aux_", "INT"))
+            -contains(c("gps", "intentos_", "introduccion", "aux_")),
+            -matches("^INT_?[0-9]+$")
           ) |>
           left_join(bd_geo, by = "Id") |>
           left_join(cols_intento, by = "Id") |>

--- a/tests/testthat/test-preparar-respuestas-int-substring.R
+++ b/tests/testthat/test-preparar-respuestas-int-substring.R
@@ -1,0 +1,49 @@
+# Regresión: preparar_respuestas() NO debe tirar variables de cuestionario que
+# contienen la subcadena "int" (internet, conoce_interurbano, op_interurbano).
+# Antes se usaba `select(-contains("INT"))`, coincidencia por subcadena e
+# insensible a mayúsculas, que las eliminaba y las dejaba 100% NULL en el
+# snapshot. El drop correcto es un `matches("^INT_?[0-9]+$")` anclado que solo
+# toca las columnas numeradas del roster de intentos.
+
+test_that("preparar_respuestas conserva variables de cuestionario con 'int' y tira solo INT numeradas", {
+  # Subclase mínima que evita el constructor complejo.
+  PreprocesoSoloPreparar <- R6::R6Class(
+    inherit = encuestar::Preproceso,
+    public = list(
+      initialize = function(bd_respuestas) {
+        self$bd_respuestas <- bd_respuestas
+      }
+    )
+  )
+
+  bd <- data.frame(
+    Id                 = 1:2,
+    finalizar          = c("Finalizar", NA),
+    cluster            = c(10, 11),
+    INT1               = c("Abrieron", "No abrieron"),
+    INT2               = c("Aceptaron", NA),
+    internet           = c("Si tiene", "No tiene"),
+    conoce_interurbano = c("Si", "No"),
+    op_interurbano     = c("Buena", NA),
+    intentos_entrevistas = c("x", "y"),
+    stringsAsFactors   = FALSE
+  )
+
+  obj <- PreprocesoSoloPreparar$new(bd)
+  obj$preparar_respuestas()
+  cols <- names(obj$bd_respuestas_preparadas)
+
+  # Las variables de cuestionario sobreviven con su valor.
+  expect_true(all(c("internet", "conoce_interurbano", "op_interurbano") %in% cols))
+  expect_equal(obj$bd_respuestas_preparadas$internet, c("Si tiene", "No tiene"))
+  expect_equal(obj$bd_respuestas_preparadas$conoce_interurbano, c("Si", "No"))
+
+  # Las columnas numeradas del roster se re-adjuntan (vienen de cols_intento).
+  expect_true(all(c("INT1", "INT2") %in% cols))
+
+  # `intentos_entrevistas` sí debe eliminarse (patrón "intentos_").
+  expect_false("intentos_entrevistas" %in% cols)
+
+  # TipoRegistro derivado correctamente.
+  expect_equal(obj$bd_respuestas_preparadas$TipoRegistro, c("Efectivo", "Otro"))
+})


### PR DESCRIPTION
## Problema

`preparar_respuestas()` (`R/clase_preprocesamiento.R`) descartaba el roster de intentos con `select(-contains("INT"))` antes de re-adjuntar solo las columnas numeradas. `tidyselect::contains()` hace coincidencia **por subcadena** con `ignore.case = TRUE` por defecto, así que `"INT"` también eliminaba cualquier variable de cuestionario cuyo nombre contiene las letras *int* (p. ej. variables con "internet" o "interurbano").

El re-attach posterior solo recuperaba `^INT[0-9]+$`, así que esas variables no se restauraban y quedaban 100% NULL en el snapshot pese a tener respuestas.

## Fix

Se reemplaza el término `"INT"` de `contains()` por un drop anclado `matches("^INT_?[0-9]+$")`, que toca exclusivamente las columnas numeradas del roster (`INT1`..`INT15` / `INT_1`..`INT_15`) sin afectar variables de cuestionario.

Se agrega prueba de regresión (`test-preparar-respuestas-int-substring.R`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)